### PR TITLE
feat: Validate AccessRequest during reconciliation

### DIFF
--- a/api/ephemeral-access/v1alpha1/accessrequest_types.go
+++ b/api/ephemeral-access/v1alpha1/accessrequest_types.go
@@ -40,6 +40,9 @@ const (
 
 	// DeniedStatus is the stage that defines the access request as refused
 	DeniedStatus Status = "denied"
+
+	// InvalidStatus is the used to identify invalid access requests
+	InvalidStatus Status = "invalid"
 )
 
 // AccessRequestSpec defines the desired state of AccessRequest
@@ -144,11 +147,6 @@ func (ar *AccessRequest) UpdateStatusHistory(newStatus Status, details string) {
 	}
 	status.History = append(status.History, history)
 	ar.Status = *status
-}
-
-// TODO
-func (ar *AccessRequest) Validate() error {
-	return nil
 }
 
 // IsExpiring will return true if this AccessRequest is expired by

--- a/api/ephemeral-access/v1alpha1/accessrequest_types.go
+++ b/api/ephemeral-access/v1alpha1/accessrequest_types.go
@@ -25,7 +25,7 @@ import (
 
 // Status defines the different stages a given access request can be
 // at a given time.
-// +kubebuilder:validation:Enum=requested;granted;expired;denied
+// +kubebuilder:validation:Enum=requested;granted;expired;denied;invalid
 type Status string
 
 const (

--- a/config/crd/bases/ephemeral-access.argoproj-labs.io_accessrequests.yaml
+++ b/config/crd/bases/ephemeral-access.argoproj-labs.io_accessrequests.yaml
@@ -118,6 +118,7 @@ spec:
                       - granted
                       - expired
                       - denied
+                      - invalid
                       type: string
                     transitionTime:
                       description: TransitionTime is the time the transition is observed
@@ -137,6 +138,7 @@ spec:
                 - granted
                 - expired
                 - denied
+                - invalid
                 type: string
               roleTemplateHash:
                 type: string

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -188,9 +188,10 @@ func (r *AccessRequestReconciler) Validate(ctx context.Context, ar *api.AccessRe
 		return fmt.Errorf("error finding AccessRequests by user and app: %w", err)
 	}
 	for _, arResp := range arList.Items {
-		// skip if it is the same AccessRequest
-		if arResp.GetName() == ar.GetName() &&
-			arResp.GetNamespace() == ar.GetNamespace() {
+		// skip if it is the same AccessRequest or if the role is different
+		if (arResp.GetName() == ar.GetName() &&
+			arResp.GetNamespace() == ar.GetNamespace()) ||
+			arResp.Spec.RoleTemplateName != ar.Spec.RoleTemplateName {
 			continue
 		}
 		if arResp.Status.RequestState == api.GrantedStatus ||

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -108,6 +108,14 @@ func (r *AccessRequestReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
+	// stop if the reconciliation was previously concluded
+	if ar.Status.RequestState == api.ExpiredStatus ||
+		ar.Status.RequestState == api.DeniedStatus ||
+		ar.Status.RequestState == api.InvalidStatus {
+		logger.Debug(fmt.Sprintf("Reconciliation concluded as the AccessRequest is %s: skipping...", string(ar.Status.RequestState)))
+		return ctrl.Result{}, nil
+	}
+
 	logger.Debug("Validating AccessRequest")
 	err = r.Validate(ctx, ar)
 	if err != nil {

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -215,7 +215,7 @@ func (r *AccessRequestReconciler) Validate(ctx context.Context, ar *api.AccessRe
 
 // isConcluded will check the status of the given AccessRequest
 // to determine if it is concluded. Concluded AccessRequest means
-// it is in Denied or Expired status.
+// it is in Denied, Expired or Invalid status.
 func isConcluded(ar *api.AccessRequest) bool {
 	switch ar.Status.RequestState {
 	case api.DeniedStatus, api.ExpiredStatus, api.InvalidStatus:

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -197,11 +197,10 @@ func (r *AccessRequestReconciler) Validate(ctx context.Context, ar *api.AccessRe
 		if arResp.Spec.RoleTemplateName != ar.Spec.RoleTemplateName {
 			continue
 		}
-		// if the existing request is pending, granted, or empty (not reconciled yet)
-		// then the new request is a duplicate and must be rejected
+		// if the existing request is pending or granted, then the new request is
+		// a duplicate and must be rejected
 		if arResp.Status.RequestState == api.GrantedStatus ||
-			arResp.Status.RequestState == api.RequestedStatus ||
-			arResp.Status.RequestState == "" {
+			arResp.Status.RequestState == api.RequestedStatus {
 			return NewAccessRequestConflictError(fmt.Sprintf("found existing AccessRequest (%s/%s) in %s state", arResp.GetNamespace(), arResp.GetName(), string(arResp.Status.RequestState)))
 		}
 	}

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -111,7 +111,7 @@ func (r *AccessRequestReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	logger.Debug("Validating AccessRequest")
 	err = r.Validate(ctx, ar)
 	if err != nil {
-		logger.Info("Validation error: %s", err)
+		logger.Info(fmt.Sprintf("Validation error: %s", err))
 		if _, ok := err.(*AccessRequestConflictError); ok {
 			logger.Error(err, "AccessRequest conflict error")
 			ar.UpdateStatusHistory(api.InvalidStatus, err.Error())
@@ -350,6 +350,8 @@ func (r *AccessRequestReconciler) callReconcileForRoleTemplate(ctx context.Conte
 	return requests
 }
 
+// findAccessRequestsByUserApp will list all AccessRequests in the given namespace
+// filtering by the given username, appName and appNamespace.
 func (r *AccessRequestReconciler) findAccessRequestsByUserApp(ctx context.Context, namespace, username, appName, appNamespace string) (*api.AccessRequestList, error) {
 	arList := &api.AccessRequestList{}
 	selectors := []fields.Selector{

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -363,13 +363,15 @@ func (r *AccessRequestReconciler) callReconcileForRoleTemplate(ctx context.Conte
 // filtering by the given username, appName and appNamespace.
 func (r *AccessRequestReconciler) findAccessRequestsByUserApp(ctx context.Context, namespace, username, appName, appNamespace string) (*api.AccessRequestList, error) {
 	arList := &api.AccessRequestList{}
-	selectors := []fields.Selector{
-		fields.OneTermEqualSelector(userField, username),
-		fields.OneTermEqualSelector(appField, appName),
-		fields.OneTermEqualSelector(appNamespaceField, appNamespace),
-	}
+	selector := fields.SelectorFromSet(
+		fields.Set{
+			userField:         username,
+			appField:          appName,
+			appNamespaceField: appNamespace,
+		})
+
 	listOps := &client.ListOptions{
-		FieldSelector: fields.AndSelectors(selectors...),
+		FieldSelector: selector,
 		Namespace:     namespace,
 	}
 

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -56,6 +56,9 @@ const (
 	AccessRequestFinalizerName = "accessrequest.ephemeral-access.argoproj-labs.io/finalizer"
 	roleTemplateField          = ".spec.roleTemplateName"
 	projectField               = ".status.targetProject"
+	userField                  = ".spec.subject.username"
+	appField                   = ".spec.application.name"
+	appNamespaceField          = ".spec.application.namespace"
 )
 
 // +kubebuilder:rbac:groups=ephemeral-access.argoproj-labs.io,resources=accessrequests,verbs=get;list;watch;create;update;patch;delete
@@ -67,24 +70,18 @@ const (
 // +kubebuilder:rbac:groups=argoproj.io,resources=appproject,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=argoproj.io,resources=application,verbs=get
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-//
-// 1. handle finalizer
-// 2. validate AccessRequest
-// 3. verify if accessrequest is expired and status is "granted"
-// 3.1 if so, remove the user from the elevated role
-// 3.2 update the accessrequest status to "expired"
-// 3.3 return
-// 4. verify if user has the necessary access to be promoted
-// 4.1 if they don't, update the accessrequest status to "denied"
-// 4.2 return
-// 5. verify if CR is approved
-// 6. retrieve the Application
-// 7. retrieve the AppProject
-// 8. assign user in the desired role in the AppProject
-// 9. update the accessrequest status to "granted"
-// 10. set the RequeueAfter in Result
+// Reconcile is the main function that will be invoked on every change in
+// AccessRequests desired state. It will:
+//  1. Handle the accessrequest finalizer
+//  2. Validate the AccessRequest
+//  3. Verify if AccessRequest is expired
+//     3.1 If so, remove the user from the elevated role
+//     3.2 Update the accessrequest status to "expired"
+//  4. Verify if user has the necessary access to be promoted
+//     4.1 If they don't, update the accessrequest status to "denied"
+//  5. Invoke preconfigured plugin to check if access can be granted
+//  8. Assign user in the desired role in the AppProject
+//  9. Update the accessrequest status to "granted"
 func (r *AccessRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Reconciliation started")
@@ -112,9 +109,15 @@ func (r *AccessRequestReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	logger.Debug("Validating AccessRequest")
-	err = ar.Validate()
+	err = r.Validate(ctx, ar)
 	if err != nil {
 		logger.Info("Validation error: %s", err)
+		if _, ok := err.(*AccessRequestConflictError); ok {
+			logger.Error(err, "AccessRequest conflict error")
+			ar.UpdateStatusHistory(api.InvalidStatus, err.Error())
+			r.Status().Update(ctx, ar)
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, fmt.Errorf("error validating the AccessRequest: %w", err)
 	}
 
@@ -154,6 +157,40 @@ func (r *AccessRequestReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	result := buildResult(status, ar, r.Config.ControllerRequeueInterval())
 	logger.Info("Reconciliation concluded", "status", status, "result", result)
 	return result, nil
+}
+
+type AccessRequestConflictError struct {
+	message string
+}
+
+func (e *AccessRequestConflictError) Error() string {
+	return e.message
+}
+
+func NewAccessRequestConflictError(msg string) *AccessRequestConflictError {
+	return &AccessRequestConflictError{
+		message: msg,
+	}
+}
+
+// Validate will verify if there are existing AccessRequests for the same
+// user/app/role already in progress.
+func (r *AccessRequestReconciler) Validate(ctx context.Context, ar *api.AccessRequest) error {
+	arList, err := r.findAccessRequestsByUserApp(ctx,
+		ar.GetNamespace(),
+		ar.Spec.Subject.Username,
+		ar.Spec.Application.Name,
+		ar.Spec.Application.Namespace)
+	if err != nil {
+		return fmt.Errorf("error finding AccessRequests by user and app: %w", err)
+	}
+	for _, ar := range arList.Items {
+		if ar.Status.RequestState == api.GrantedStatus ||
+			ar.Status.RequestState == api.RequestedStatus {
+			return NewAccessRequestConflictError(fmt.Sprintf("found existing AccessRequest in %s state", string(ar.Status.RequestState)))
+		}
+	}
+	return nil
 }
 
 // isConcluded will check the status of the given AccessRequest
@@ -277,19 +314,16 @@ func (r *AccessRequestReconciler) handleFinalizer(ctx context.Context, ar *api.A
 	return true, nil
 }
 
-// findObjectsForRoleTemplate will retrieve all AccessRequest resources referencing
+// callReconcileForRoleTemplate will retrieve all AccessRequest resources referencing
 // the given roleTemplate and build a list of reconcile requests to be sent to the
 // controller. Only non-concluded AccessRequests will be added to the reconciliation
 // list. An AccessRequest is defined as concluded if their status is Expired or Denied.
-func (r *AccessRequestReconciler) findObjectsForRoleTemplate(ctx context.Context, roleTemplate client.Object) []reconcile.Request {
+func (r *AccessRequestReconciler) callReconcileForRoleTemplate(ctx context.Context, roleTemplate client.Object) []reconcile.Request {
 	logger := log.FromContext(ctx)
 	logger.Debug(fmt.Sprintf("RoleTemplate %s updated: searching for associated AccessRequests...", roleTemplate.GetName()))
 	attachedAccessRequests := &api.AccessRequestList{}
 	listOps := &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(roleTemplateField, roleTemplate.GetName()),
-		// This makes a requirement that the AccessRequest has to live in the
-		// same namespace as the AppProject.
-		Namespace: roleTemplate.GetNamespace(),
 	}
 	err := r.List(ctx, attachedAccessRequests, listOps)
 	if err != nil {
@@ -316,11 +350,30 @@ func (r *AccessRequestReconciler) findObjectsForRoleTemplate(ctx context.Context
 	return requests
 }
 
-// findObjectsForProject will retrieve all AccessRequest resources referencing
+func (r *AccessRequestReconciler) findAccessRequestsByUserApp(ctx context.Context, namespace, username, appName, appNamespace string) (*api.AccessRequestList, error) {
+	arList := &api.AccessRequestList{}
+	selectors := []fields.Selector{
+		fields.OneTermEqualSelector(userField, username),
+		fields.OneTermEqualSelector(appField, appName),
+		fields.OneTermEqualSelector(appNamespaceField, appNamespace),
+	}
+	listOps := &client.ListOptions{
+		FieldSelector: fields.AndSelectors(selectors...),
+		Namespace:     namespace,
+	}
+
+	err := r.List(ctx, arList, listOps)
+	if err != nil {
+		return nil, fmt.Errorf("List error: %w", err)
+	}
+	return arList, nil
+}
+
+// callReconcileForProject will retrieve all AccessRequest resources referencing
 // the given project and build a list of reconcile requests to be sent to the
 // controller. Only non-concluded AccessRequests will be added to the reconciliation
 // list. An AccessRequest is defined as concluded if their status is Expired or Denied.
-func (r *AccessRequestReconciler) findObjectsForProject(ctx context.Context, project client.Object) []reconcile.Request {
+func (r *AccessRequestReconciler) callReconcileForProject(ctx context.Context, project client.Object) []reconcile.Request {
 	logger := log.FromContext(ctx)
 	logger.Debug(fmt.Sprintf("Project %s updated: searching for associated AccessRequests...", project.GetName()))
 	associatedAccessRequests := &api.AccessRequestList{}
@@ -390,23 +443,69 @@ func createRoleTemplateIndex(mgr ctrl.Manager) error {
 	return nil
 }
 
+// createRoleTemplateIndex will create an AccessRequest index by the following fields:
+// - .spec.subject.username
+// - .spec.application.name
+// - .spec.application.namespace
+func createUserAppIndex(mgr ctrl.Manager) error {
+	err := mgr.GetFieldIndexer().
+		IndexField(context.Background(), &api.AccessRequest{}, userField, func(rawObj client.Object) []string {
+			ar := rawObj.(*api.AccessRequest)
+			if ar.Spec.Subject.Username == "" {
+				return nil
+			}
+			return []string{ar.Spec.Subject.Username}
+		})
+	if err != nil {
+		return fmt.Errorf("error creating username field index: %w", err)
+	}
+	err = mgr.GetFieldIndexer().
+		IndexField(context.Background(), &api.AccessRequest{}, appField, func(rawObj client.Object) []string {
+			ar := rawObj.(*api.AccessRequest)
+			if ar.Spec.Application.Name == "" {
+				return nil
+			}
+			return []string{ar.Spec.Application.Name}
+		})
+	if err != nil {
+		return fmt.Errorf("error creating application name field index: %w", err)
+	}
+	err = mgr.GetFieldIndexer().
+		IndexField(context.Background(), &api.AccessRequest{}, appNamespaceField, func(rawObj client.Object) []string {
+			ar := rawObj.(*api.AccessRequest)
+			if ar.Spec.Application.Namespace == "" {
+				return nil
+			}
+			return []string{ar.Spec.Application.Namespace}
+		})
+	if err != nil {
+		return fmt.Errorf("error creating application namespace field index: %w", err)
+	}
+	return nil
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *AccessRequestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	err := createProjectIndex(mgr)
 	if err != nil {
-		return fmt.Errorf("create index error: %w", err)
+		return fmt.Errorf("project index error: %w", err)
 	}
 	err = createRoleTemplateIndex(mgr)
 	if err != nil {
-		return fmt.Errorf("create index error: %w", err)
+		return fmt.Errorf("roleTemplate index error: %w", err)
 	}
+	err = createUserAppIndex(mgr)
+	if err != nil {
+		return fmt.Errorf("userapp index error: %w", err)
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&api.AccessRequest{}).
 		Watches(&api.RoleTemplate{},
-			handler.EnqueueRequestsFromMapFunc(r.findObjectsForRoleTemplate),
+			handler.EnqueueRequestsFromMapFunc(r.callReconcileForRoleTemplate),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
 		Watches(&argocd.AppProject{},
-			handler.EnqueueRequestsFromMapFunc(r.findObjectsForProject),
+			handler.EnqueueRequestsFromMapFunc(r.callReconcileForProject),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
 		Complete(r)
 }

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -187,7 +187,7 @@ func (r *AccessRequestReconciler) Validate(ctx context.Context, ar *api.AccessRe
 	for _, ar := range arList.Items {
 		if ar.Status.RequestState == api.GrantedStatus ||
 			ar.Status.RequestState == api.RequestedStatus {
-			return NewAccessRequestConflictError(fmt.Sprintf("found existing AccessRequest in %s state", string(ar.Status.RequestState)))
+			return NewAccessRequestConflictError(fmt.Sprintf("found existing AccessRequest (%s/%s) in %s state", ar.GetNamespace(), ar.GetName(), string(ar.Status.RequestState)))
 		}
 	}
 	return nil

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -184,10 +184,15 @@ func (r *AccessRequestReconciler) Validate(ctx context.Context, ar *api.AccessRe
 	if err != nil {
 		return fmt.Errorf("error finding AccessRequests by user and app: %w", err)
 	}
-	for _, ar := range arList.Items {
-		if ar.Status.RequestState == api.GrantedStatus ||
-			ar.Status.RequestState == api.RequestedStatus {
-			return NewAccessRequestConflictError(fmt.Sprintf("found existing AccessRequest (%s/%s) in %s state", ar.GetNamespace(), ar.GetName(), string(ar.Status.RequestState)))
+	for _, arResp := range arList.Items {
+		// skip if it is the same AccessRequest
+		if arResp.GetName() == ar.GetName() &&
+			arResp.GetNamespace() == ar.GetNamespace() {
+			continue
+		}
+		if arResp.Status.RequestState == api.GrantedStatus ||
+			arResp.Status.RequestState == api.RequestedStatus {
+			return NewAccessRequestConflictError(fmt.Sprintf("found existing AccessRequest (%s/%s) in %s state", arResp.GetNamespace(), arResp.GetName(), string(ar.Status.RequestState)))
 		}
 	}
 	return nil

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -109,9 +109,7 @@ func (r *AccessRequestReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// stop if the reconciliation was previously concluded
-	if ar.Status.RequestState == api.ExpiredStatus ||
-		ar.Status.RequestState == api.DeniedStatus ||
-		ar.Status.RequestState == api.InvalidStatus {
+	if isConcluded(ar) {
 		logger.Debug(fmt.Sprintf("Reconciliation concluded as the AccessRequest is %s: skipping...", string(ar.Status.RequestState)))
 		return ctrl.Result{}, nil
 	}
@@ -220,7 +218,7 @@ func (r *AccessRequestReconciler) Validate(ctx context.Context, ar *api.AccessRe
 // it is in Denied or Expired status.
 func isConcluded(ar *api.AccessRequest) bool {
 	switch ar.Status.RequestState {
-	case api.DeniedStatus, api.ExpiredStatus:
+	case api.DeniedStatus, api.ExpiredStatus, api.InvalidStatus:
 		return true
 	default:
 		return false

--- a/internal/controller/accessrequest_controller_test.go
+++ b/internal/controller/accessrequest_controller_test.go
@@ -654,7 +654,7 @@ var _ = Describe("AccessRequest Controller", func() {
 				race1AR := utils.NewAccessRequest("race1", namespace, appName, "racerole", subject01)
 				race1AR.Spec.Duration = metav1.Duration{Duration: time.Minute}
 				race2AR := utils.NewAccessRequest("race2", namespace, appName, "racerole", subject01)
-				race1AR.Spec.Duration = metav1.Duration{Duration: time.Minute}
+				race2AR.Spec.Duration = metav1.Duration{Duration: time.Minute}
 				go func() {
 					err := k8sClient.Create(ctx, race1AR)
 					Expect(err).NotTo(HaveOccurred())
@@ -704,8 +704,8 @@ var _ = Describe("AccessRequest Controller", func() {
 					totalValid++
 				}
 
-				Expect(totalValid).To(Equal(1), "totalValid mismatch")
 				Expect(totalInvalid).To(Equal(1), "totalInvalid mismatch")
+				Expect(totalValid).To(Equal(1), "totalValid mismatch")
 			})
 		})
 


### PR DESCRIPTION
We decided to implement this validation as part of the reconciliation loop for simplicity. The other alternative would be to deploy a ValidationWebhook. However that solution would be more complex to implement and deploy as admission controllers require certificates to be provided.