### PR TITLE
feat(backend-role): adding list verbs on applications and appprojects for backend-role

### DIFF
--- a/config/backend/role.yaml
+++ b/config/backend/role.yaml
@@ -14,12 +14,14 @@ rules:
       - applications
     verbs:
       - get
+      - list
   - apiGroups:
       - argoproj.io
     resources:
       - appprojects
     verbs:
       - get
+      - list
   - apiGroups:
       - ephemeral-access.argoproj-labs.io
     resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -10,6 +10,7 @@ rules:
   - applications
   verbs:
   - get
+  - list
 - apiGroups:
   - argoproj.io
   resources:


### PR DESCRIPTION
Added list permissions for the backend role. Currently testing this out in a sandbox environment and ran into permission issues. 

```
E1118 23:16:59.075594       1 reflector.go:150] pkg/mod/k8s.io/client-go@v0.30.0/tools/cache/reflector.go:232: Failed to watch argoproj.io/v1alpha1, Kind=AppProject: failed to list argoproj.io/v1alpha1, Kind=AppProject: appprojects.argoproj.io is forbidden: User "system:serviceaccount:argocd-sandbox:backend" cannot list resource "appprojects" in API group "argoproj.io" at the cluster scope
```
```
2024-11-18T23:10:51.041Z	ERROR	backend error	{"error": "error getting application"}
W1118 23:11:26.306366       1 reflector.go:547] pkg/mod/k8s.io/client-go@v0.30.0/tools/cache/reflector.go:232: failed to list argoproj.io/v1alpha1, Kind=Application: applications.argoproj.io is forbidden: User "system:serviceaccount:argocd-sandbox:backend" cannot list resource "applications" in API group "argoproj.io" at the cluster scope