### PR TITLE
fix: Do not attempt to cache unstructured objects causing OOMKilled

### DIFF
--- a/internal/backend/k8s.go
+++ b/internal/backend/k8s.go
@@ -143,24 +143,13 @@ func NewK8sPersister(config *rest.Config, logger log.Logger) (*K8sPersister, err
 		return nil, fmt.Errorf("error adding AccessBinding index for field %s: %w", accessBindingRoleField, err)
 	}
 
-	// err = cache.IndexField(context.Background(), &api.AccessBinding{}, accessBindingRoleField, func(obj client.Object) []string {
-	// 	b := obj.(*api.AccessBinding)
-	// 	if b.Spec.RoleTemplateRef.Name == "" {
-	// 		return nil
-	// 	}
-	// 	return []string{b.Spec.RoleTemplateRef.Name}
-	// })
-	// if err != nil {
-	// 	return nil, fmt.Errorf("error adding AccessBinding index for field %s: %w", accessBindingRoleField, err)
-	// }
-	//
 	clientOpts := client.Options{
 		HTTPClient: httpClient,
 		Scheme:     scheme.Scheme,
 		Mapper:     mapper,
 		Cache: &client.CacheOptions{
 			Reader:       cache,
-			Unstructured: true,
+			Unstructured: false,
 		},
 	}
 	k8sClient, err := client.New(config, clientOpts)

--- a/internal/backend/k8s.go
+++ b/internal/backend/k8s.go
@@ -91,7 +91,7 @@ func NewK8sPersister(config *rest.Config, logger log.Logger) (*K8sPersister, err
 		HTTPClient:                  httpClient,
 		Scheme:                      scheme.Scheme,
 		Mapper:                      mapper,
-		ReaderFailOnMissingInformer: true,
+		ReaderFailOnMissingInformer: false,
 		DefaultWatchErrorHandler:    watchErrorHandler,
 	}
 	cache, err := cache.New(config, cacheOpts)

--- a/internal/backend/k8s.go
+++ b/internal/backend/k8s.go
@@ -165,10 +165,6 @@ func NewK8sPersister(config *rest.Config, logger log.Logger) (*K8sPersister, err
 }
 
 func isExpiredError(err error) bool {
-	// In Kubernetes 1.17 and earlier, the api server returns both apierrors.StatusReasonExpired and
-	// apierrors.StatusReasonGone for HTTP 410 (Gone) status code responses. In 1.18 the kube server is more consistent
-	// and always returns apierrors.StatusReasonExpired. For backward compatibility we can only remove the apierrors.IsGone
-	// check when we fully drop support for Kubernetes 1.17 servers from reflectors.
 	return apierrors.IsResourceExpired(err) || apierrors.IsGone(err)
 }
 

--- a/internal/backend/service_test.go
+++ b/internal/backend/service_test.go
@@ -41,6 +41,7 @@ func serviceSetup(t *testing.T) *serviceFixture {
 	logger := mocks.NewMockLogger(t)
 	logger.EXPECT().Debug(mock.Anything, mock.Anything).Maybe()
 	logger.EXPECT().Debug(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+	logger.EXPECT().Debug(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
 	logger.EXPECT().Info(mock.Anything, mock.Anything).Maybe()
 	svc := backend.NewDefaultService(persister, logger, ControllerNamespace, AccessRequestDuration)
 	return &serviceFixture{


### PR DESCRIPTION
- **chore: add debug logs in backend service**
- **add cache watch error handler**
- **fix: don't read unstructured from the cache**
- **cleanup**
