### PR TITLE
fix: skip reconciliation if AccessRequest is already granted

### DIFF
--- a/internal/backend/api.go
+++ b/internal/backend/api.go
@@ -278,6 +278,12 @@ func toAccessRequestResponseBody(ar *api.AccessRequest) AccessRequestResponseBod
 			}
 		}
 	}
+	// This is to keep backwards compatibility as old AccessRequests wont have the InitiatedStatus
+	// in the history
+	if requestedAt == "" && ar.Status.RequestState != api.InvalidStatus && ar.Status.RequestState != "" {
+		requestedAt = ar.GetCreationTimestamp().Format(time.RFC3339)
+	}
+
 	message := ""
 	if len(ar.Status.History) > 0 && ar.Status.History[len(ar.Status.History)-1].Details != nil {
 		message = *ar.Status.History[len(ar.Status.History)-1].Details

--- a/internal/backend/service_test.go
+++ b/internal/backend/service_test.go
@@ -807,7 +807,7 @@ func Test_defaultAccessRequestSort(t *testing.T) {
 		require.Equal(t, second, items[1])
 		require.Equal(t, third, items[2])
 	})
-	t.Run("array should be ordered by creation for the same status, ordinal and role name", func(t *testing.T) {
+	t.Run("array should be descending ordered by creation for the same status, ordinal and role name", func(t *testing.T) {
 		// Given
 		base := utils.NewAccessRequestCreated(utils.WithRole())
 		first := base.DeepCopy()
@@ -829,9 +829,9 @@ func Test_defaultAccessRequestSort(t *testing.T) {
 		// Then
 		require.Equal(t, 3, len(items))
 		// compare each object because it makes it easier to investigate on test failures
-		require.Equal(t, first, items[0])
+		require.Equal(t, third, items[0])
 		require.Equal(t, second, items[1])
-		require.Equal(t, third, items[2])
+		require.Equal(t, first, items[2])
 	})
 }
 

--- a/internal/controller/service.go
+++ b/internal/controller/service.go
@@ -79,6 +79,12 @@ func (s *Service) HandlePermission(ctx context.Context, ar *api.AccessRequest, a
 		s.updateStatus(ctx, ar, api.InitiatedStatus, "", RoleTemplateHash(rt))
 	}
 
+	// if accessRequest is already granted but not yet expired there is no
+	// permission to be modified.
+	if ar.Status.RequestState == api.GrantedStatus {
+		return api.GrantedStatus, nil
+	}
+
 	// invoke the configured plugin to check if the ar.Spec.Subject
 	// is allowed to get their access elevated. If no plugin is configured
 	// it will always allow.

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -236,21 +236,6 @@ func ToInvalidState() AccessRequestMutation {
 
 // ToRequestedState transition the AccessRequest to a requested status
 func ToRequestedState() AccessRequestMutation {
-	// return func(ar *api.AccessRequest) {
-	// 	ar.Status = api.AccessRequestStatus{
-	// 		RequestState:     api.RequestedStatus,
-	// 		TargetProject:    "my-proj",
-	// 		RoleName:         "ephemeral-some-role",
-	// 		RoleTemplateHash: "0123456789",
-	// 		History: []api.AccessRequestHistory{
-	// 			{
-	// 				TransitionTime: metav1.Now(),
-	// 				RequestState:   api.RequestedStatus,
-	// 			},
-	// 		},
-	// 	}
-	// }
-
 	return func(ar *api.AccessRequest) {
 		now := metav1.Now()
 		ar.Status.RequestState = api.RequestedStatus


### PR DESCRIPTION
Signed-off-by: Leonardo Luz Almeida <leonardo_almeida@intuit.com>
