### PR TITLE
fix: make the plugin script available to goreleaser docker

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,6 +47,8 @@ dockers:
       - quay.io/argoprojlabs/argocd-ephemeral-access-plugin:latest
       - quay.io/argoprojlabs/argocd-ephemeral-access-plugin:{{ .Tag }}
     dockerfile: plugin.Dockerfile
+    extra_files:
+      - scripts/plugin-installer.sh
     skip_push: '{{ .IsSnapshot }}'
     build_flag_templates:
       - '--pull'


### PR DESCRIPTION
Signed-off-by: Leonardo Luz Almeida <leonardo_almeida@intuit.com>
