### PR TITLE
feat: Add metrics around plugin calls

### DIFF
--- a/internal/controller/metrics/metrics.go
+++ b/internal/controller/metrics/metrics.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"github.com/argoproj-labs/argocd-ephemeral-access/pkg/plugin"
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -13,13 +14,40 @@ var (
 		},
 		[]string{"accessRequestStatus"},
 	)
+
+	// PluginOperationsTotal counts the total number of plugin operations. The plugin operation can be either
+	// revoke_access or grant_access.
+	pluginOperationsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "plugin_operations_total",
+			Help: "Total number of plugin operations by type and result",
+		},
+		[]string{"operation", "result"},
+	)
 )
 
 func init() {
 	metrics.Registry.MustRegister(accessRequestStatusTotal)
+	metrics.Registry.MustRegister(pluginOperationsTotal)
 }
 
 // IncrementAccessRequestCounter increments the counter for a given AccessRequest status
 func IncrementAccessRequestCounter(status string) {
 	accessRequestStatusTotal.WithLabelValues(status).Inc()
+}
+
+// RecordPluginOperationResult records the result of a plugin operation
+func RecordPluginOperationResult(operation string, result interface{}) {
+	var resultString string
+	switch r := result.(type) {
+	case plugin.GrantStatus:
+		resultString = string(r)
+	case plugin.RevokeStatus:
+		resultString = string(r)
+	case error:
+		resultString = "error"
+	default:
+		resultString = "unknown"
+	}
+	pluginOperationsTotal.WithLabelValues(operation, resultString).Inc()
 }

--- a/internal/controller/metrics/metrics_test.go
+++ b/internal/controller/metrics/metrics_test.go
@@ -1,7 +1,11 @@
 package metrics
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/argoproj-labs/argocd-ephemeral-access/pkg/plugin"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
@@ -34,5 +38,71 @@ func TestIncrementAccessRequestCounter(t *testing.T) {
 
 		count := metric.Counter.GetValue()
 		assert.Equal(t, expected, count, "Incorrect count for status %s", status)
+	}
+}
+
+func TestRecordPluginOperationResult(t *testing.T) {
+	// Test different plugin operation results
+	pluginOperationsTotal.Reset()
+
+	tests := []struct {
+		name           string
+		operation      string
+		result         interface{}
+		expectedResult string
+	}{
+		{
+			name:           "grant granted",
+			operation:      "grant_access",
+			result:         plugin.GrantStatusGranted,
+			expectedResult: string(plugin.GrantStatusGranted),
+		},
+		{
+			name:           "grant pending",
+			operation:      "grant_access",
+			result:         plugin.GrantStatusPending,
+			expectedResult: string(plugin.GrantStatusPending),
+		},
+		{
+			name:           "grant denied",
+			operation:      "grant_access",
+			result:         plugin.GrantStatusDenied,
+			expectedResult: string(plugin.GrantStatusDenied),
+		},
+		{
+			name:           "revoke revoked",
+			operation:      "revoke_access",
+			result:         plugin.RevokeStatusRevoked,
+			expectedResult: string(plugin.RevokeStatusRevoked),
+		},
+		{
+			name:           "revoke pending",
+			operation:      "revoke_access",
+			result:         plugin.RevokeStatusPending,
+			expectedResult: string(plugin.RevokeStatusPending),
+		},
+		{
+			name:           "error result",
+			operation:      "grant_access",
+			result:         fmt.Errorf("test error"),
+			expectedResult: "error",
+		},
+		{
+			name:           "unknown result",
+			operation:      "grant_access",
+			result:         "some string",
+			expectedResult: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pluginOperationsTotal.Reset()
+			RecordPluginOperationResult(tt.operation, tt.result)
+
+			// Check that the counter was incremented
+			count := testutil.ToFloat64(pluginOperationsTotal.WithLabelValues(tt.operation, tt.expectedResult))
+			assert.Equal(t, float64(1), count, "Counter should be incremented by 1")
+		})
 	}
 }


### PR DESCRIPTION
Adds metric for:
```
Name: "plugin_operations_total",
Help: "Total number of plugin operations by type and result"
```
Example from logs:
```
`# HELP plugin_operations_total Total number of plugin operations by type and result
# TYPE plugin_operations_total counter
plugin_operations_total{operation="grant_access",result="grant-pending"} 3`
```

This will tell us the result of plugin operation, and if it has errors