### PR TITLE
feat(controller): update predicates to GenerationChanged

### DIFF
--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -733,12 +733,13 @@ func (r *AccessRequestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&api.AccessRequest{}).
+		For(&api.AccessRequest{},
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&api.RoleTemplate{},
 			handler.EnqueueRequestsFromMapFunc(r.callReconcileForRoleTemplate),
-			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&argocd.AppProject{},
 			handler.EnqueueRequestsFromMapFunc(r.callReconcileForProject),
-			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }

--- a/internal/controller/service.go
+++ b/internal/controller/service.go
@@ -77,7 +77,10 @@ func (s *Service) HandlePermission(ctx context.Context, ar *api.AccessRequest, a
 		logger.Debug("Initializing status")
 		ar.Status.TargetProject = app.Spec.Project
 		ar.Status.RoleName = rt.AppProjectRoleName(app.GetName(), app.GetNamespace())
-		s.updateStatus(ctx, ar, api.InitiatedStatus, "", RoleTemplateHash(rt))
+		err := s.updateStatus(ctx, ar, api.InitiatedStatus, "", RoleTemplateHash(rt))
+		if err != nil {
+			return "", fmt.Errorf("error initializing access request status: %w", err)
+		}
 	}
 
 	// if accessRequest is already granted but not yet expired there is no


### PR DESCRIPTION
Updated predicates in AccessRequestReconciler to use `GenerationChangedPredicate` instead of `ResourceVersionChangedPredicate` for better handling of resource updates.

- Modified predicates for AccessRequest, RoleTemplate, and AppProject.
- Ensures reconciliation triggers only on spec changes.

Signed-off-by: Leonardo Luz Almeida <leonardo_almeida@intuit.com>
