### PR TITLE
feat(controller): handle project changes in the Application resource

### DIFF
--- a/api/ephemeral-access/v1alpha1/accessrequest_types.go
+++ b/api/ephemeral-access/v1alpha1/accessrequest_types.go
@@ -220,6 +220,12 @@ func (ar *AccessRequest) IsConcluded() bool {
 	}
 }
 
+// IsInitialized returns true if the AccessRequest has a non-empty RequestState
+// in its Status, indicating that it has been initialized.
+func (ar *AccessRequest) IsInitialized() bool {
+	return ar.Status.RequestState != ""
+}
+
 // AccessRequestList contains a list of AccessRequest
 // +kubebuilder:object:root=true
 type AccessRequestList struct {

--- a/api/ephemeral-access/v1alpha1/roletemplate_types.go
+++ b/api/ephemeral-access/v1alpha1/roletemplate_types.go
@@ -24,6 +24,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// RoleNamePrefix defines the prefix used for all ephemeral role names.
+	RoleNamePrefix = "ephemeral-"
+)
+
 // RoleTemplate is the Schema for the roletemplates API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
@@ -116,7 +121,7 @@ func (rt *RoleTemplate) execTemplate(tmpl *template.Template, projName, appName,
 // roleName will return the role name to be used in the AppProject
 func (rt *RoleTemplate) AppProjectRoleName(appName, namespace string) string {
 	roleName := rt.Spec.Name
-	return fmt.Sprintf("ephemeral-%s-%s-%s", roleName, namespace, appName)
+	return fmt.Sprintf("%s%s-%s-%s", RoleNamePrefix, roleName, namespace, appName)
 }
 
 func init() {

--- a/internal/backend/api.go
+++ b/internal/backend/api.go
@@ -280,7 +280,7 @@ func toAccessRequestResponseBody(ar *api.AccessRequest) AccessRequestResponseBod
 	}
 	// This is to keep backwards compatibility as old AccessRequests wont have the InitiatedStatus
 	// in the history
-	if requestedAt == "" && ar.Status.RequestState != api.InvalidStatus && ar.Status.RequestState != "" {
+	if requestedAt == "" && ar.Status.RequestState != api.InvalidStatus && ar.IsInitialized() {
 		requestedAt = ar.GetCreationTimestamp().Format(time.RFC3339)
 	}
 

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -770,6 +770,10 @@ func ProjectChangeShouldTriggerReconcile(newProj, oldProj *argocd.AppProject) bo
 
 	for _, newRole := range newProj.Spec.Roles {
 		if !slices.ContainsFunc(oldProj.Spec.Roles, func(oldRole argocd.ProjectRole) bool {
+			if newRole.Name != oldRole.Name ||
+				newRole.Description != oldRole.Description {
+				return false
+			}
 			if len(newRole.Policies) != len(oldRole.Policies) {
 				return false
 			}
@@ -794,8 +798,7 @@ func ProjectChangeShouldTriggerReconcile(newProj, oldProj *argocd.AppProject) bo
 					return false
 				}
 			}
-			return newRole.Name == oldRole.Name &&
-				newRole.Description == oldRole.Description
+			return true
 		}) {
 			return true
 		}

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -31,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder" // Required for Watching
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"   // Required for Watching
 	"sigs.k8s.io/controller-runtime/pkg/predicate" // Required for Watching
 	"sigs.k8s.io/controller-runtime/pkg/reconcile" // Required for Watching
@@ -591,6 +593,56 @@ func (r *AccessRequestReconciler) callReconcileForProject(ctx context.Context, p
 	return requests
 }
 
+// callReconcileForApplication finds all AccessRequest resources associated with the given Application object
+// and returns a list of reconcile.Requests for those that are not yet concluded. This is typically used to
+// trigger reconciliation of AccessRequests when their associated Application is updated.
+//
+// Parameters:
+//
+//	ctx - The context for the request, used for logging and cancellation.
+//	app - The Application object for which to find associated AccessRequests.
+//
+// Returns:
+//
+//	A slice of reconcile.Requests for each associated AccessRequest that is not concluded.
+//	Returns nil if no such AccessRequests are found or if an error occurs during listing.
+func (r *AccessRequestReconciler) callReconcileForApplication(ctx context.Context, app client.Object) []reconcile.Request {
+	logger := log.FromContext(ctx)
+	logger.Debug(fmt.Sprintf("Application %s/%s updated: searching for associated AccessRequests...", app.GetNamespace(), app.GetName()))
+	associatedAccessRequests := &api.AccessRequestList{}
+	selector := fields.SelectorFromSet(
+		fields.Set{
+			appField:          app.GetName(),
+			appNamespaceField: app.GetNamespace(),
+		})
+	listOps := &client.ListOptions{
+		FieldSelector: selector,
+	}
+	err := r.List(ctx, associatedAccessRequests, listOps)
+	if err != nil {
+		logger.Error(err, "findObjectsForProject error: list k8s resources error")
+		return []reconcile.Request{}
+	}
+
+	requests := []reconcile.Request{}
+	for _, ar := range associatedAccessRequests.Items {
+		if !ar.IsConcluded() {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      ar.GetName(),
+					Namespace: ar.GetNamespace(),
+				},
+			})
+		}
+	}
+	totalRequests := len(requests)
+	if totalRequests == 0 {
+		return nil
+	}
+	logger.Debug(fmt.Sprintf("Found %d associated AccessRequests with Application %s/%s. Reconciling...", totalRequests, app.GetNamespace(), app.GetName()))
+	return requests
+}
+
 // createProjectIndex will create an AccessRequest index by project to allow
 // fetching all objects referencing a given AppProject.
 func createProjectIndex(mgr ctrl.Manager) error {
@@ -679,6 +731,108 @@ func createUserAppIndex(mgr ctrl.Manager) error {
 	return nil
 }
 
+// ProjectChangedPredicate returns a predicate that triggers reconciliation
+// only when an ArgoCD AppProject has changed in a way that should trigger
+// a reconcile, as determined by ProjectChangeShouldTriggerReconcile.
+// It ignores create, delete, and generic events.
+func ProjectChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			newProj := e.ObjectNew.(*argocd.AppProject)
+			oldProj := e.ObjectOld.(*argocd.AppProject)
+
+			return ProjectChangeShouldTriggerReconcile(newProj, oldProj)
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+// ProjectChangeShouldTriggerReconcile determines whether a change between two AppProject
+// objects should trigger a reconcile. It compares the roles, policies, JWT tokens, and groups
+// between the new and old project specifications. If there are any differences in the number
+// of roles, policies, JWT tokens, groups, or in the role names or descriptions, it returns true.
+// If either project is nil, it also returns true.
+func ProjectChangeShouldTriggerReconcile(newProj, oldProj *argocd.AppProject) bool {
+	if newProj == nil || oldProj == nil {
+		return true
+	}
+	if len(newProj.Spec.Roles) != len(oldProj.Spec.Roles) {
+		return true
+	}
+
+	for _, newRole := range newProj.Spec.Roles {
+		if !slices.ContainsFunc(oldProj.Spec.Roles, func(oldRole argocd.ProjectRole) bool {
+			if len(newRole.Policies) != len(oldRole.Policies) {
+				return false
+			}
+			if len(newRole.JWTTokens) != len(oldRole.JWTTokens) {
+				return false
+			}
+			if len(newRole.Groups) != len(oldRole.Groups) {
+				return false
+			}
+			for _, policy := range newRole.Policies {
+				if !slices.Contains(oldRole.Policies, policy) {
+					return false
+				}
+			}
+			for _, jwtToken := range newRole.JWTTokens {
+				if !slices.Contains(oldRole.JWTTokens, jwtToken) {
+					return false
+				}
+			}
+			for _, group := range newRole.Groups {
+				if !slices.Contains(oldRole.Groups, group) {
+					return false
+				}
+			}
+			return newRole.Name == oldRole.Name &&
+				newRole.Description == oldRole.Description
+		}) {
+			return true
+		}
+	}
+	return false
+}
+
+// ApplicationChangedPredicate returns a predicate that triggers reconciliation
+// when an ArgoCD Application's project changes, or when the Application is deleted.
+// It ignores create and generic events.
+func ApplicationChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			newApp := e.ObjectNew.(*argocd.Application)
+			oldApp := e.ObjectOld.(*argocd.Application)
+
+			if newApp == nil || oldApp == nil {
+				return true
+			}
+
+			if newApp.Spec.Project != oldApp.Spec.Project {
+				return true
+			}
+			return false
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return true
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *AccessRequestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	err := createProjectIndex(mgr)
@@ -702,6 +856,9 @@ func (r *AccessRequestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&argocd.AppProject{},
 			handler.EnqueueRequestsFromMapFunc(r.callReconcileForProject),
-			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+			builder.WithPredicates(ProjectChangedPredicate())).
+		Watches(&argocd.Application{},
+			handler.EnqueueRequestsFromMapFunc(r.callReconcileForApplication),
+			builder.WithPredicates(ApplicationChangedPredicate())).
 		Complete(r)
 }

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -768,42 +768,61 @@ func ProjectChangeShouldTriggerReconcile(newProj, oldProj *argocd.AppProject) bo
 		return true
 	}
 
-	for _, newRole := range newProj.Spec.Roles {
-		if !slices.ContainsFunc(oldProj.Spec.Roles, func(oldRole argocd.ProjectRole) bool {
-			if newRole.Name != oldRole.Name ||
-				newRole.Description != oldRole.Description {
-				return false
-			}
-			if len(newRole.Policies) != len(oldRole.Policies) {
-				return false
-			}
-			if len(newRole.JWTTokens) != len(oldRole.JWTTokens) {
-				return false
-			}
-			if len(newRole.Groups) != len(oldRole.Groups) {
-				return false
-			}
-			for _, policy := range newRole.Policies {
-				if !slices.Contains(oldRole.Policies, policy) {
-					return false
-				}
-			}
-			for _, jwtToken := range newRole.JWTTokens {
-				if !slices.Contains(oldRole.JWTTokens, jwtToken) {
-					return false
-				}
-			}
-			for _, group := range newRole.Groups {
-				if !slices.Contains(oldRole.Groups, group) {
-					return false
-				}
-			}
-			return true
-		}) {
+	for _, oldRole := range oldProj.Spec.Roles {
+		if !HasRole(newProj.Spec.Roles, oldRole) {
 			return true
 		}
 	}
 	return false
+}
+
+// HasRole checks if the given role exists in the list of roles.
+// It compares the role's Name and Description, and ensures that the Policies,
+// JWTTokens, and Groups slices are of equal length and contain the same elements.
+// Returns true if an equivalent role is found, otherwise returns false.
+func HasRole(roles []argocd.ProjectRole, role argocd.ProjectRole) bool {
+	for _, r := range roles {
+		if r.Name == role.Name && r.Description == role.Description {
+			if !MatchRolePoliciesAndTokens(r, role.Policies, role.JWTTokens) {
+				return false
+			}
+			if len(r.Groups) != len(role.Groups) {
+				return false
+			}
+			for _, group := range r.Groups {
+				if !slices.Contains(role.Groups, group) {
+					return false
+				}
+			}
+
+			return true
+		}
+	}
+	return false
+}
+
+// MatchRolePoliciesAndTokens compares two ProjectRole objects and returns true
+// if both have identical Policies and JWTTokens slices (regardless of order).
+// Returns false if the lengths differ or any element is missing in either slice.
+func MatchRolePoliciesAndTokens(role argocd.ProjectRole, policies []string, tokens []argocd.JWTToken) bool {
+	if len(role.Policies) != len(policies) {
+		return false
+	}
+	if len(role.JWTTokens) != len(tokens) {
+		return false
+	}
+
+	for _, policy := range role.Policies {
+		if !slices.Contains(policies, policy) {
+			return false
+		}
+	}
+	for _, jwtToken := range role.JWTTokens {
+		if !slices.Contains(tokens, jwtToken) {
+			return false
+		}
+	}
+	return true
 }
 
 // ApplicationChangedPredicate returns a predicate that triggers reconciliation

--- a/internal/controller/accessrequest_controller.go
+++ b/internal/controller/accessrequest_controller.go
@@ -769,18 +769,18 @@ func ProjectChangeShouldTriggerReconcile(newProj, oldProj *argocd.AppProject) bo
 	}
 
 	for _, oldRole := range oldProj.Spec.Roles {
-		if !HasRole(newProj.Spec.Roles, oldRole) {
+		if !hasRole(newProj.Spec.Roles, oldRole) {
 			return true
 		}
 	}
 	return false
 }
 
-// HasRole checks if the given role exists in the list of roles.
+// hasRole checks if the given role exists in the list of roles.
 // It compares the role's Name and Description, and ensures that the Policies,
 // JWTTokens, and Groups slices are of equal length and contain the same elements.
 // Returns true if an equivalent role is found, otherwise returns false.
-func HasRole(roles []argocd.ProjectRole, role argocd.ProjectRole) bool {
+func hasRole(roles []argocd.ProjectRole, role argocd.ProjectRole) bool {
 	for _, r := range roles {
 		if r.Name == role.Name && r.Description == role.Description {
 			if !MatchRolePoliciesAndTokens(r, role.Policies, role.JWTTokens) {

--- a/internal/controller/accessrequest_controller_test.go
+++ b/internal/controller/accessrequest_controller_test.go
@@ -918,10 +918,6 @@ var _ = Describe("AccessRequest Controller", func() {
 			})
 		})
 	})
-	Context("Deleting RoleTemplate used by multiple AccessRequests", Ordered, func() {
-	})
-	Context("Deleting Project used by multiple AccessRequests", Ordered, func() {
-	})
 })
 
 func TestProjectChangeShouldTriggerReconcile(t *testing.T) {

--- a/internal/controller/accessrequest_controller_test.go
+++ b/internal/controller/accessrequest_controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"errors"
 	"fmt"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -832,3 +833,163 @@ var _ = Describe("AccessRequest Controller", func() {
 	Context("Deleting Project used by multiple AccessRequests", Ordered, func() {
 	})
 })
+
+func TestProjectChangeShouldTriggerReconcile(t *testing.T) {
+	role1 := argocd.ProjectRole{
+		Name:        "role1",
+		Description: "desc1",
+		Policies:    []string{"policy1", "policy2"},
+		JWTTokens: []argocd.JWTToken{
+			{ID: "token1"},
+		},
+		Groups: []string{"group1"},
+	}
+	role2 := argocd.ProjectRole{
+		Name:        "role2",
+		Description: "desc2",
+		Policies:    []string{"policy3"},
+		JWTTokens: []argocd.JWTToken{
+			{ID: "token2"},
+		},
+		Groups: []string{"group2"},
+	}
+
+	tests := []struct {
+		name    string
+		oldProj func() *argocd.AppProject
+		newProj func() *argocd.AppProject
+		want    bool
+	}{
+		{
+			name: "tokens length changed",
+			oldProj: func() *argocd.AppProject {
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{role1}}}
+			},
+			newProj: func() *argocd.AppProject {
+				r := role1.DeepCopy()
+				r.JWTTokens = []argocd.JWTToken{}
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{*r}}}
+			},
+			want: true,
+		},
+		{
+			name: "tokens changed",
+			oldProj: func() *argocd.AppProject {
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{role1}}}
+			},
+			newProj: func() *argocd.AppProject {
+				r := role1.DeepCopy()
+				r.JWTTokens = []argocd.JWTToken{{ID: "token1-changed"}}
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{*r}}}
+			},
+			want: true,
+		},
+		{
+			name: "groups length changed",
+			oldProj: func() *argocd.AppProject {
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{role1}}}
+			},
+			newProj: func() *argocd.AppProject {
+				r := role1.DeepCopy()
+				r.Groups = append(r.Groups, "group3")
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{*r}}}
+			},
+			want: true,
+		},
+		{
+			name: "groups changed",
+			oldProj: func() *argocd.AppProject {
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{role1}}}
+			},
+			newProj: func() *argocd.AppProject {
+				r := role1.DeepCopy()
+				r.Groups[0] = "group1-changed"
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{*r}}}
+			},
+			want: true,
+		},
+		{
+			name: "roles length changed",
+			oldProj: func() *argocd.AppProject {
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{role1}}}
+			},
+			newProj: func() *argocd.AppProject {
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{role1, role2}}}
+			},
+			want: true,
+		},
+		{
+			name: "role name changed",
+			oldProj: func() *argocd.AppProject {
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{role1}}}
+			},
+			newProj: func() *argocd.AppProject {
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{
+					{Name: "role1-changed", Description: "desc1", Policies: []string{"policy1", "policy2"}},
+				},
+				}}
+			},
+			want: true,
+		},
+		{
+			name: "role description changed",
+			oldProj: func() *argocd.AppProject {
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{role1}}}
+			},
+			newProj: func() *argocd.AppProject {
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{
+					{Name: "role1", Description: "desc1-changed", Policies: []string{"policy1", "policy2"}}},
+				}}
+			},
+			want: true,
+		},
+		{
+			name: "role policies changed",
+			oldProj: func() *argocd.AppProject {
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{role1}}}
+			},
+			newProj: func() *argocd.AppProject {
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{
+					{Name: "role1", Description: "desc1", Policies: []string{"policy1"}},
+				}}}
+			},
+			want: true,
+		},
+		{
+			name: "no change",
+			oldProj: func() *argocd.AppProject {
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{role2, role1}}}
+			},
+			newProj: func() *argocd.AppProject {
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{role1, role2}}}
+			},
+			want: false,
+		},
+		{
+			name:    "old project nil",
+			oldProj: func() *argocd.AppProject { return nil },
+			newProj: func() *argocd.AppProject {
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{role1, role2}}}
+			},
+			want: true,
+		},
+		{
+			name: "new project nil",
+			oldProj: func() *argocd.AppProject {
+				return &argocd.AppProject{Spec: argocd.AppProjectSpec{Roles: []argocd.ProjectRole{role1, role2}}}
+			},
+			newProj: func() *argocd.AppProject { return nil },
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // capture range variable
+		t.Run(tt.name, func(t *testing.T) {
+			got := ProjectChangeShouldTriggerReconcile(tt.newProj(), tt.oldProj())
+			if got != tt.want {
+				t.Errorf("ProjectChangeShouldTriggerReconcile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/accessrequest_controller_test.go
+++ b/internal/controller/accessrequest_controller_test.go
@@ -660,6 +660,96 @@ var _ = Describe("AccessRequest Controller", func() {
 		})
 	})
 
+	Context("Changing an Application", Ordered, func() {
+		const (
+			namespace             = "test-application-watch"
+			arName01              = "test-ar-app-watch"
+			appprojectName        = "sample-test-project"
+			appName               = "some-application"
+			roleTemplateName      = "role-template-watch-test"
+			roleTemplateNamespace = "test-application-watch-rt"
+			roleName              = "super-user"
+			subject01             = "some-user"
+			expectedPolicy        = "original-policy"
+		)
+
+		var f *fixture
+		var r resources
+		policies := []string{expectedPolicy}
+
+		When("used by an active AccessRequests", func() {
+			AfterAll(func() {
+				deleteNamespace(f)
+			})
+			BeforeAll(func() {
+				r = resources{
+					arName:                arName01,
+					appName:               appName,
+					namespace:             namespace,
+					appProjName:           appprojectName,
+					roleTemplateName:      roleTemplateName,
+					roleTemplateNamespace: roleTemplateNamespace,
+					roleName:              roleName,
+					subject:               subject01,
+					policies:              policies,
+				}
+				f = setup(r)
+			})
+			It("will apply the roletemplate resource in k8s", func() {
+				err := k8sClient.Create(ctx, f.roletemplate)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("will apply the AccessRequests resources in k8s", func() {
+				f.accessrequests[0].Spec.Duration = metav1.Duration{Duration: time.Second * 5}
+				for _, ar := range f.accessrequests {
+					err := k8sClient.Create(ctx, ar)
+					Expect(err).NotTo(HaveOccurred())
+				}
+			})
+			It("will verify if the AccessRequest is created", func() {
+				returnedAR := &api.AccessRequest{}
+				Eventually(func() api.Status {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(f.accessrequests[0]), returnedAR)
+					Expect(err).NotTo(HaveOccurred())
+					return returnedAR.Status.RequestState
+				}, timeout, interval).ShouldNot(BeEmpty())
+				Expect(returnedAR.Status.History).NotTo(BeEmpty())
+				Expect(returnedAR.Status.History[0].RequestState).To(Equal(api.InitiatedStatus))
+			})
+			It("will invalidate the AccessRequest when the target project is changed in the app", func() {
+
+				By("modifying the Application project")
+				appYaml := testdata.ApplicationYaml
+				app, err := utils.YamlToUnstructured(appYaml)
+				Expect(err).NotTo(HaveOccurred())
+				app.SetName(appName)
+				app.SetNamespace(namespace)
+				unstructured.SetNestedField(app.Object, "another-project", "spec", "project")
+				// The dynamic client is used to create the resource with all fields
+				// defined in the official Argo CD CRD
+				_, err = dynClient.Resource(appResource).
+					Namespace(r.namespace).
+					Apply(ctx, r.appName, app, metav1.ApplyOptions{
+						FieldManager: "argocd-controller",
+					})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("checking if AccessRequest is invalidated")
+				returnedAR := &api.AccessRequest{}
+				Eventually(func() api.Status {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(f.accessrequests[0]), returnedAR)
+					Expect(err).NotTo(HaveOccurred())
+					return returnedAR.Status.RequestState
+				}, timeout, interval).Should(Equal(api.InvalidStatus))
+				Expect(returnedAR.Status.RequestState).NotTo(BeEmpty())
+				lastHistory := returnedAR.Status.History[len(returnedAR.Status.History)-1]
+				Expect(lastHistory.RequestState).To(Equal(api.InvalidStatus))
+				Expect(lastHistory.Details).NotTo(BeNil())
+				Expect(*lastHistory.Details).To(ContainSubstring("project changed"))
+			})
+		})
+	})
+
 	Context("Validating AccessRequests", Ordered, func() {
 		const (
 			namespace             = "test-ar-validation"

--- a/internal/controller/accessrequest_controller_test.go
+++ b/internal/controller/accessrequest_controller_test.go
@@ -922,7 +922,7 @@ var _ = Describe("AccessRequest Controller", func() {
 
 func TestProjectChangeShouldTriggerReconcile(t *testing.T) {
 	role1 := argocd.ProjectRole{
-		Name:        "role1",
+		Name:        fmt.Sprintf("%srole1", api.RoleNamePrefix),
 		Description: "desc1",
 		Policies:    []string{"policy1", "policy2"},
 		JWTTokens: []argocd.JWTToken{
@@ -931,7 +931,7 @@ func TestProjectChangeShouldTriggerReconcile(t *testing.T) {
 		Groups: []string{"group1"},
 	}
 	role2 := argocd.ProjectRole{
-		Name:        "role2",
+		Name:        fmt.Sprintf("%srole2", api.RoleNamePrefix),
 		Description: "desc2",
 		Policies:    []string{"policy3"},
 		JWTTokens: []argocd.JWTToken{

--- a/internal/controller/service.go
+++ b/internal/controller/service.go
@@ -106,6 +106,31 @@ func (s *Service) HandlePermission(ctx context.Context, ar *api.AccessRequest) (
 		return api.InvalidStatus, nil
 	}
 
+	// If the AccessRequest status is initialized and the target project is different from the
+	// application project, it means that the AccessRequest was created for a different project.
+	// In this case, we need to remove the access from the old project and update the status.
+	if ar.Status.TargetProject != "" && ar.Status.TargetProject != app.Spec.Project {
+		logger.Info("Application project changed", "old", ar.Status.TargetProject, "new", app.Spec.Project)
+		oldRole, err := s.getRenderedRole(ctx, ar, ar.Status.TargetProject)
+		if err != nil {
+			return "", fmt.Errorf("error getting rendered RoleTemplate for old project: %w", err)
+		}
+
+		// Only need to remove existing access if the AccessRequest is in a granted state.
+		if ar.Status.RequestState == api.GrantedStatus {
+			err = s.RemoveArgoCDAccess(ctx, ar, oldRole)
+			if err != nil {
+				return "", fmt.Errorf("error removing access for changed target project: %w", err)
+			}
+		}
+		msg := fmt.Sprintf("The application project changed from %s to %s.", ar.Status.TargetProject, app.Spec.Project)
+		err = s.updateStatus(ctx, ar, api.InvalidStatus, msg, RoleTemplateHash(oldRole))
+		if err != nil {
+			return "", fmt.Errorf("error updating access request status after target project change: %w", err)
+		}
+		return api.InvalidStatus, nil
+	}
+
 	role, err := s.getRenderedRole(ctx, ar, app.Spec.Project)
 	if err != nil {
 		return "", fmt.Errorf("error getting rendered RoleTemplate: %w", err)
@@ -128,25 +153,6 @@ func (s *Service) HandlePermission(ctx context.Context, ar *api.AccessRequest) (
 		err := s.updateStatus(ctx, ar, api.InitiatedStatus, "", RoleTemplateHash(role))
 		if err != nil {
 			return "", fmt.Errorf("error initializing access request status: %w", err)
-		}
-	}
-
-	if ar.Status.TargetProject != app.Spec.Project {
-		logger.Info("Application project changed", "old", ar.Status.TargetProject, "new", app.Spec.Project)
-		oldRole, err := s.getRenderedRole(ctx, ar, ar.Status.TargetProject)
-		if err != nil {
-			return "", fmt.Errorf("error getting rendered RoleTemplate for old project: %w", err)
-		}
-
-		// if the target project changed, we need to remove the access from the old project
-		err = s.RemoveArgoCDAccess(ctx, ar, oldRole)
-		if err != nil {
-			return "", fmt.Errorf("error removing access for changed target project: %w", err)
-		}
-		msg := fmt.Sprintf("The application project changed from %s to %s.", ar.Status.TargetProject, app.Spec.Project)
-		err = s.updateStatus(ctx, ar, api.InvalidStatus, msg, RoleTemplateHash(oldRole))
-		if err != nil {
-			return "", fmt.Errorf("error updating access request status after target project change: %w", err)
 		}
 	}
 

--- a/internal/controller/service.go
+++ b/internal/controller/service.go
@@ -388,7 +388,7 @@ func (s *Service) ensureRoleIsSynced(ctx context.Context, ar *api.AccessRequest,
 			return fmt.Errorf("error getting Argo CD Project %s/%s: %w", projNamespace, projName, err)
 		}
 
-		if roleInSync(project, ar, rt) {
+		if isRoleInSync(project, ar, rt) {
 			logger.Debug("Project role is already in sync")
 			return nil
 		}
@@ -580,11 +580,11 @@ func removeSubjectFromRole(project *argocd.AppProject, ar *api.AccessRequest, rt
 	}
 }
 
-// roleInSync checks if the given AppProject's role corresponding to the AccessRequest and RoleTemplate
+// isRoleInSync checks if the given AppProject's role corresponding to the AccessRequest and RoleTemplate
 // is synchronized. It verifies that the role exists, its description matches, the subject is present
 // in the role's groups if the request is granted, and the role's policies and tokens match the template.
 // Returns true if the role is in sync, false otherwise.
-func roleInSync(project *argocd.AppProject, ar *api.AccessRequest, rt *api.RoleTemplate) bool {
+func isRoleInSync(project *argocd.AppProject, ar *api.AccessRequest, rt *api.RoleTemplate) bool {
 	// This variable is used to track if the role was deleted.
 	inSync := false
 	roleName := rt.AppProjectRoleName(ar.Spec.Application.Name, ar.Spec.Application.Namespace)

--- a/internal/controller/service.go
+++ b/internal/controller/service.go
@@ -70,6 +70,71 @@ func (s *Service) getRenderedRole(ctx context.Context, ar *api.AccessRequest, pr
 	return rt, nil
 }
 
+// ValidateProject validates that the Argo CD Application is associated with a valid project
+// and that the AccessRequest matches the current project. It updates the AccessRequest status
+// to invalid in the following cases:
+// - The Application project isn't set.
+// - The Application project changed.
+// - The Application project does not exist.
+//
+// Returns true if the project is valid and exists, false otherwise. Returns an error if any
+// status update or project retrieval fails.
+func (s *Service) ValidateProject(ctx context.Context, app *argocd.Application, ar *api.AccessRequest) (bool, error) {
+	logger := log.FromContext(ctx)
+
+	// The Argo CD Application must be associated with a project. If not, the AccessRequest
+	// is updated with invalid status.
+	if app.Spec.Project == "" {
+		err := s.updateStatus(ctx, ar, api.InvalidStatus, "Application does not have a project defined", "")
+		if err != nil {
+			return false, fmt.Errorf("error updating status to invalid when app project is not set: %w", err)
+		}
+		return false, nil
+	}
+
+	// If the AccessRequest status is initialized and the target project is different from the
+	// application project, it means that the AccessRequest was created for a different project.
+	// In this case, we need to remove the access from the old project and update the status.
+	if ar.Status.TargetProject != "" && ar.Status.TargetProject != app.Spec.Project {
+		logger.Info("Application project changed", "old", ar.Status.TargetProject, "new", app.Spec.Project)
+		oldRole, err := s.getRenderedRole(ctx, ar, ar.Status.TargetProject)
+		if err != nil {
+			return false, fmt.Errorf("error getting rendered RoleTemplate for old project: %w", err)
+		}
+
+		// Only need to remove existing access if the AccessRequest is in a granted state.
+		if ar.Status.RequestState == api.GrantedStatus {
+			err = s.RemoveArgoCDAccess(ctx, ar, oldRole)
+			if err != nil {
+				return false, fmt.Errorf("error removing access for changed target project: %w", err)
+			}
+		}
+		msg := fmt.Sprintf("The application project changed from %s to %s.", ar.Status.TargetProject, app.Spec.Project)
+		err = s.updateStatus(ctx, ar, api.InvalidStatus, msg, RoleTemplateHash(oldRole))
+		if err != nil {
+			return false, fmt.Errorf("error updating access request status after target project change: %w", err)
+		}
+		return false, nil
+	}
+
+	// If the project does not exist, the AccessRequest status is updated to invalid.
+	projName := app.Spec.Project
+	projNamespace := ar.GetNamespace()
+	_, err := s.getProject(ctx, projName, projNamespace)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			msg := fmt.Sprintf("Argo CD Project %s/%s not found", projNamespace, projName)
+			err := s.updateStatus(ctx, ar, api.InvalidStatus, msg, "")
+			if err != nil {
+				return false, fmt.Errorf("error updating status to invalid when project not found: %w", err)
+			}
+			return false, nil
+		}
+		return false, fmt.Errorf("error getting Argo CD Project %s/%s: %w", projNamespace, projName, err)
+	}
+	return true, nil
+}
+
 // handlePermission will analyse the given ar and proceed with granting
 // or removing Argo CD access for the subject listed in the AccessRequest.
 // The following validations will be executed:
@@ -96,38 +161,11 @@ func (s *Service) HandlePermission(ctx context.Context, ar *api.AccessRequest) (
 		return "", fmt.Errorf("error getting Argo CD Application: %w", err)
 	}
 
-	// The Argo CD Application must be associated with a project. If not, the AccessRequest
-	// is updated with invalid status.
-	if app.Spec.Project == "" {
-		err := s.updateStatus(ctx, ar, api.InvalidStatus, "Application does not have a project defined", "")
-		if err != nil {
-			return "", fmt.Errorf("error updating status to invalid: %w", err)
-		}
-		return api.InvalidStatus, nil
+	validProject, err := s.ValidateProject(ctx, app, ar)
+	if err != nil {
+		return "", fmt.Errorf("error validating project: %w", err)
 	}
-
-	// If the AccessRequest status is initialized and the target project is different from the
-	// application project, it means that the AccessRequest was created for a different project.
-	// In this case, we need to remove the access from the old project and update the status.
-	if ar.Status.TargetProject != "" && ar.Status.TargetProject != app.Spec.Project {
-		logger.Info("Application project changed", "old", ar.Status.TargetProject, "new", app.Spec.Project)
-		oldRole, err := s.getRenderedRole(ctx, ar, ar.Status.TargetProject)
-		if err != nil {
-			return "", fmt.Errorf("error getting rendered RoleTemplate for old project: %w", err)
-		}
-
-		// Only need to remove existing access if the AccessRequest is in a granted state.
-		if ar.Status.RequestState == api.GrantedStatus {
-			err = s.RemoveArgoCDAccess(ctx, ar, oldRole)
-			if err != nil {
-				return "", fmt.Errorf("error removing access for changed target project: %w", err)
-			}
-		}
-		msg := fmt.Sprintf("The application project changed from %s to %s.", ar.Status.TargetProject, app.Spec.Project)
-		err = s.updateStatus(ctx, ar, api.InvalidStatus, msg, RoleTemplateHash(oldRole))
-		if err != nil {
-			return "", fmt.Errorf("error updating access request status after target project change: %w", err)
-		}
+	if !validProject {
 		return api.InvalidStatus, nil
 	}
 

--- a/internal/controller/service.go
+++ b/internal/controller/service.go
@@ -131,6 +131,25 @@ func (s *Service) HandlePermission(ctx context.Context, ar *api.AccessRequest) (
 		}
 	}
 
+	if ar.Status.TargetProject != app.Spec.Project {
+		logger.Info("Application project changed", "old", ar.Status.TargetProject, "new", app.Spec.Project)
+		oldRole, err := s.getRenderedRole(ctx, ar, ar.Status.TargetProject)
+		if err != nil {
+			return "", fmt.Errorf("error getting rendered RoleTemplate for old project: %w", err)
+		}
+
+		// if the target project changed, we need to remove the access from the old project
+		err = s.RemoveArgoCDAccess(ctx, ar, oldRole)
+		if err != nil {
+			return "", fmt.Errorf("error removing access for changed target project: %w", err)
+		}
+		msg := fmt.Sprintf("The application project changed from %s to %s.", ar.Status.TargetProject, app.Spec.Project)
+		err = s.updateStatus(ctx, ar, api.InvalidStatus, msg, RoleTemplateHash(oldRole))
+		if err != nil {
+			return "", fmt.Errorf("error updating access request status after target project change: %w", err)
+		}
+	}
+
 	// if accessRequest is already granted but not yet expired there is no
 	// permission to be modified but it is still necessary to ensure that
 	// the AppProject role is synced.

--- a/internal/controller/service.go
+++ b/internal/controller/service.go
@@ -95,7 +95,7 @@ func (s *Service) ValidateProject(ctx context.Context, app *argocd.Application, 
 	// If the AccessRequest status is initialized and the target project is different from the
 	// application project, it means that the AccessRequest was created for a different project.
 	// In this case, we need to remove the access from the old project and update the status.
-	if ar.Status.TargetProject != "" && ar.Status.TargetProject != app.Spec.Project {
+	if ar.IsInitialized() && ar.Status.TargetProject != app.Spec.Project {
 		logger.Info("Application project changed", "old", ar.Status.TargetProject, "new", app.Spec.Project)
 		oldRole, err := s.getRenderedRole(ctx, ar, ar.Status.TargetProject)
 		if err != nil {
@@ -184,7 +184,7 @@ func (s *Service) HandlePermission(ctx context.Context, ar *api.AccessRequest) (
 	}
 
 	// initialize the status if not done yet
-	if ar.Status.RequestState == "" {
+	if !ar.IsInitialized() {
 		logger.Debug("Initializing status")
 		ar.Status.TargetProject = app.Spec.Project
 		ar.Status.RoleName = role.AppProjectRoleName(app.GetName(), app.GetNamespace())

--- a/internal/controller/service.go
+++ b/internal/controller/service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha1"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/argoproj-labs/argocd-ephemeral-access/internal/controller/metrics"
 
@@ -367,10 +368,17 @@ func (s *Service) RemoveArgoCDAccess(ctx context.Context, ar *api.AccessRequest,
 // - error: An error if the synchronization fails, otherwise nil.
 func (s *Service) ensureRoleIsSynced(ctx context.Context, ar *api.AccessRequest, rt *api.RoleTemplate) error {
 	logger := log.FromContext(ctx)
-	logger.Info("Syncing role")
 
 	projName := ar.Status.TargetProject
 	projNamespace := ar.GetNamespace()
+	values := []interface{}{
+		"project.name", projName,
+		"project.namespace", projNamespace,
+		"project.role", rt.AppProjectRoleName(ar.Spec.Application.Name, ar.Spec.Application.Namespace),
+	}
+
+	logger = logger.WithValues(values...)
+	logger.Info("Ensuring role is synced")
 
 	// Retry the synchronization process on conflict errors.
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -380,9 +388,17 @@ func (s *Service) ensureRoleIsSynced(ctx context.Context, ar *api.AccessRequest,
 			return fmt.Errorf("error getting Argo CD Project %s/%s: %w", projNamespace, projName, err)
 		}
 
+		if roleInSync(project, ar, rt) {
+			logger.Debug("Project role is already in sync")
+			return nil
+		}
+
 		// Prepare a patch for updating the project policies.
 		patch := client.MergeFromWithOptions(project.DeepCopy(), client.MergeFromWithOptimisticLock{})
 		updateProjectPolicies(project, ar, rt)
+		if ar.Status.RequestState == api.GrantedStatus {
+			addSubjectInRole(project, ar, rt)
+		}
 
 		logger.Debug("Patching AppProject")
 		opts := []client.PatchOption{client.FieldOwner("ephemeral-access-controller")}
@@ -562,6 +578,31 @@ func removeSubjectFromRole(project *argocd.AppProject, ar *api.AccessRequest, rt
 			project.Spec.Roles[idx].Groups = groups
 		}
 	}
+}
+
+// roleInSync checks if the given AppProject's role corresponding to the AccessRequest and RoleTemplate
+// is synchronized. It verifies that the role exists, its description matches, the subject is present
+// in the role's groups if the request is granted, and the role's policies and tokens match the template.
+// Returns true if the role is in sync, false otherwise.
+func roleInSync(project *argocd.AppProject, ar *api.AccessRequest, rt *api.RoleTemplate) bool {
+	// This variable is used to track if the role was deleted.
+	inSync := false
+	roleName := rt.AppProjectRoleName(ar.Spec.Application.Name, ar.Spec.Application.Namespace)
+	for _, role := range project.Spec.Roles {
+		if role.Name == roleName {
+			if role.Description != rt.Spec.Description {
+				return false
+			}
+			if ar.Status.RequestState == api.GrantedStatus && !slices.Contains(role.Groups, ar.Spec.Subject.Username) {
+				return false
+			}
+			if !MatchRolePoliciesAndTokens(role, rt.Spec.Policies, []argocd.JWTToken{}) {
+				return false
+			}
+			inSync = true
+		}
+	}
+	return inSync
 }
 
 // updateProjectPolicies will update the given project to match all Policies

--- a/internal/controller/service_test.go
+++ b/internal/controller/service_test.go
@@ -22,6 +22,32 @@ import (
 )
 
 func TestHandlePermission(t *testing.T) {
+	newApp := func(prj string) *argocd.Application {
+		return &argocd.Application{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{},
+			Spec: argocd.ApplicationSpec{
+				Project: prj,
+			},
+		}
+	}
+	newRoleTemplate := func(spec api.RoleTemplateSpec) *api.RoleTemplate {
+		return &api.RoleTemplate{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{},
+			Spec:       spec,
+		}
+	}
+	newProject := func(roles []argocd.ProjectRole) *argocd.AppProject {
+		return &argocd.AppProject{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{},
+			Spec: argocd.AppProjectSpec{
+				Roles: roles,
+			},
+		}
+	}
+
 	t.Run("will set AccessRequest to invalid if the application project is not set", func(t *testing.T) {
 		// Given
 		updatedAR := &api.AccessRequest{}
@@ -60,6 +86,127 @@ func TestHandlePermission(t *testing.T) {
 		assert.NotNil(t, status, "status is nil")
 		assert.Equal(t, api.InvalidStatus, status, "status must be invalid")
 		assert.Equal(t, api.InvalidStatus, updatedAR.Status.RequestState)
+	})
+	t.Run("will invalidate the AccessRequest when application project change", func(t *testing.T) {
+		setup := func(clientMock *mocks.MockK8sClient, app *argocd.Application, rt *api.RoleTemplate, prj *argocd.AppProject, updatedProj *argocd.AppProject, updatedAR *api.AccessRequest) {
+			clientMock.EXPECT().
+				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Application")).
+				RunAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					appLocal := obj.(*argocd.Application)
+					appLocal.Spec = app.Spec
+					return nil
+				}).Maybe()
+			clientMock.EXPECT().
+				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.RoleTemplate")).
+				RunAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					rtLocal := obj.(*api.RoleTemplate)
+					rtLocal.Spec = rt.DeepCopy().Spec
+					return nil
+				}).Maybe()
+			clientMock.EXPECT().
+				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.AppProject")).
+				RunAndReturn(func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+					prjLocal := obj.(*argocd.AppProject)
+					prjLocal.Spec = prj.DeepCopy().Spec
+					return nil
+				}).Maybe()
+			clientMock.EXPECT().
+				Patch(mock.Anything, mock.AnythingOfType("*v1alpha1.AppProject"), mock.Anything, mock.Anything).
+				RunAndReturn(func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					updatedProj.Spec = obj.(*argocd.AppProject).Spec
+					return nil
+				}).Maybe()
+			resourceWriterMock := mocks.NewMockSubResourceWriter(t)
+			resourceWriterMock.EXPECT().Update(mock.Anything, mock.AnythingOfType("*v1alpha1.AccessRequest")).
+				RunAndReturn(func(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+					ar := obj.(*api.AccessRequest)
+					updatedAR.Spec = ar.Spec
+					updatedAR.Status = ar.Status
+					return nil
+				}).Maybe()
+			clientMock.EXPECT().Status().Return(resourceWriterMock).Maybe()
+		}
+		t.Run("will revoke access from the old project", func(t *testing.T) {
+			// Given
+			updatedAR := &api.AccessRequest{}
+			updatedProject := &argocd.AppProject{}
+
+			app := newApp("NEW_PROJECT")
+			rt := newRoleTemplate(api.RoleTemplateSpec{
+				Name:        "some-role-template",
+				Description: "some role description",
+				Policies:    []string{"policy1", "policy2"},
+			})
+			prj := newProject(
+				[]argocd.ProjectRole{
+					{
+						Name:        "ephemeral-some-role-template-someAppNs-someApp",
+						Description: "some role description",
+						Policies:    []string{"policy1", "policy2"},
+						JWTTokens:   []argocd.JWTToken{},
+						Groups:      []string{"some-user", "user-to-be-removed"},
+					},
+				},
+			)
+
+			clientMock := mocks.NewMockK8sClient(t)
+			setup(clientMock, app, rt, prj, updatedProject, updatedAR)
+			ar := utils.NewAccessRequest("test", "default", "someApp", "someAppNs", "someRole", "someRoleNs", "user-to-be-removed")
+			ar.Status.TargetProject = "someProject"
+			ar.Status.RequestState = api.GrantedStatus
+			svc := controller.NewService(clientMock, nil, nil)
+
+			// When
+			status, err := svc.HandlePermission(context.Background(), ar)
+
+			// Then
+			assert.NoError(t, err)
+			assert.NotNil(t, status, "status is nil")
+			assert.Equal(t, api.InvalidStatus, status, "status must be invalid")
+			assert.Equal(t, api.InvalidStatus, updatedAR.Status.RequestState)
+			expectedGroups := []string{"some-user"}
+			assert.Equal(t, expectedGroups, updatedProject.Spec.Roles[0].Groups, "groups must be updated")
+		})
+		t.Run("will not remove access if AccessRequest in not granted", func(t *testing.T) {
+			// Given
+			updatedAR := &api.AccessRequest{}
+			updatedProject := &argocd.AppProject{}
+
+			app := newApp("NEW_PROJECT")
+			rt := newRoleTemplate(api.RoleTemplateSpec{
+				Name:        "some-role-template",
+				Description: "some role description",
+				Policies:    []string{"policy1", "policy2"},
+			})
+			prj := newProject(
+				[]argocd.ProjectRole{
+					{
+						Name:        "ephemeral-some-role-template-someAppNs-someApp",
+						Description: "some role description",
+						Policies:    []string{"policy1", "policy2"},
+						JWTTokens:   []argocd.JWTToken{},
+						Groups:      []string{"some-user", "another-user"},
+					},
+				},
+			)
+
+			clientMock := mocks.NewMockK8sClient(t)
+			setup(clientMock, app, rt, prj, updatedProject, updatedAR)
+			ar := utils.NewAccessRequest("test", "default", "someApp", "someAppNs", "someRole", "someRoleNs", "new-user")
+			ar.Status.TargetProject = "someProject"
+			ar.Status.RequestState = api.RequestedStatus
+			svc := controller.NewService(clientMock, nil, nil)
+
+			// When
+			status, err := svc.HandlePermission(context.Background(), ar)
+
+			// Then
+			assert.NoError(t, err)
+			assert.NotNil(t, status, "status is nil")
+			assert.Equal(t, api.InvalidStatus, status, "status must be invalid")
+			assert.Equal(t, api.InvalidStatus, updatedAR.Status.RequestState)
+			assert.Len(t, updatedProject.Spec.Roles, 0, "project roles must not be changed")
+		})
 	})
 	t.Run("will handle application not found", func(t *testing.T) {
 		setup := func(clientMock *mocks.MockK8sClient, roleTemplate *api.RoleTemplate, appProj *argocd.AppProject, updatedProj *argocd.AppProject, updatedAR *api.AccessRequest) {
@@ -270,7 +417,7 @@ func TestHandlePermission(t *testing.T) {
 				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Application")).
 				RunAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 					app := obj.(*argocd.Application)
-					app.Spec.Project = "some-project"
+					app.Spec.Project = "someProject"
 					return nil
 				})
 			clientMock.EXPECT().
@@ -312,7 +459,7 @@ func TestHandlePermission(t *testing.T) {
 				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Application")).
 				RunAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 					app := obj.(*argocd.Application)
-					app.Spec.Project = "some-project"
+					app.Spec.Project = "someProject"
 					return nil
 				})
 			clientMock.EXPECT().

--- a/internal/controller/service_test.go
+++ b/internal/controller/service_test.go
@@ -48,46 +48,7 @@ func TestHandlePermission(t *testing.T) {
 		}
 	}
 
-	t.Run("will set AccessRequest to invalid if the application project is not set", func(t *testing.T) {
-		// Given
-		updatedAR := &api.AccessRequest{}
-		invalidApp := &argocd.Application{
-			TypeMeta:   metav1.TypeMeta{},
-			ObjectMeta: metav1.ObjectMeta{},
-			Spec: argocd.ApplicationSpec{
-				Project: "",
-			},
-		}
-		clientMock := mocks.NewMockK8sClient(t)
-		clientMock.EXPECT().
-			Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Application")).
-			RunAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-				app := obj.(*argocd.Application)
-				app.Spec = invalidApp.Spec
-				return nil
-			}).Maybe()
-		resourceWriterMock := mocks.NewMockSubResourceWriter(t)
-		resourceWriterMock.EXPECT().Update(mock.Anything, mock.AnythingOfType("*v1alpha1.AccessRequest")).
-			RunAndReturn(func(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
-				ar := obj.(*api.AccessRequest)
-				updatedAR.Spec = ar.Spec
-				updatedAR.Status = ar.Status
-				return nil
-			}).Maybe()
-		clientMock.EXPECT().Status().Return(resourceWriterMock).Maybe()
-		ar := utils.NewAccessRequest("test", "default", "someApp", "someAppNs", "someRole", "someRoleNs", "user-to-be-removed")
-		svc := controller.NewService(clientMock, nil, nil)
-
-		// When
-		status, err := svc.HandlePermission(context.Background(), ar)
-
-		// Then
-		assert.NoError(t, err)
-		assert.NotNil(t, status, "status is nil")
-		assert.Equal(t, api.InvalidStatus, status, "status must be invalid")
-		assert.Equal(t, api.InvalidStatus, updatedAR.Status.RequestState)
-	})
-	t.Run("will invalidate the AccessRequest when application project change", func(t *testing.T) {
+	t.Run("will validate the project", func(t *testing.T) {
 		setup := func(clientMock *mocks.MockK8sClient, app *argocd.Application, rt *api.RoleTemplate, prj *argocd.AppProject, updatedProj *argocd.AppProject, updatedAR *api.AccessRequest) {
 			clientMock.EXPECT().
 				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Application")).
@@ -126,7 +87,46 @@ func TestHandlePermission(t *testing.T) {
 				}).Maybe()
 			clientMock.EXPECT().Status().Return(resourceWriterMock).Maybe()
 		}
-		t.Run("will revoke access from the old project", func(t *testing.T) {
+		t.Run("will invalidate the AccessRequest if the application project is not set", func(t *testing.T) {
+			// Given
+			updatedAR := &api.AccessRequest{}
+			invalidApp := &argocd.Application{
+				TypeMeta:   metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: argocd.ApplicationSpec{
+					Project: "",
+				},
+			}
+			clientMock := mocks.NewMockK8sClient(t)
+			clientMock.EXPECT().
+				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Application")).
+				RunAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					app := obj.(*argocd.Application)
+					app.Spec = invalidApp.Spec
+					return nil
+				}).Maybe()
+			resourceWriterMock := mocks.NewMockSubResourceWriter(t)
+			resourceWriterMock.EXPECT().Update(mock.Anything, mock.AnythingOfType("*v1alpha1.AccessRequest")).
+				RunAndReturn(func(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+					ar := obj.(*api.AccessRequest)
+					updatedAR.Spec = ar.Spec
+					updatedAR.Status = ar.Status
+					return nil
+				}).Maybe()
+			clientMock.EXPECT().Status().Return(resourceWriterMock).Maybe()
+			ar := utils.NewAccessRequest("test", "default", "someApp", "someAppNs", "someRole", "someRoleNs", "user-to-be-removed")
+			svc := controller.NewService(clientMock, nil, nil)
+
+			// When
+			status, err := svc.HandlePermission(context.Background(), ar)
+
+			// Then
+			assert.NoError(t, err)
+			assert.NotNil(t, status, "status is nil")
+			assert.Equal(t, api.InvalidStatus, status, "status must be invalid")
+			assert.Equal(t, api.InvalidStatus, updatedAR.Status.RequestState)
+		})
+		t.Run("will invalidate the AccessRequest and revoke access when application project change", func(t *testing.T) {
 			// Given
 			updatedAR := &api.AccessRequest{}
 			updatedProject := &argocd.AppProject{}
@@ -167,7 +167,7 @@ func TestHandlePermission(t *testing.T) {
 			expectedGroups := []string{"some-user"}
 			assert.Equal(t, expectedGroups, updatedProject.Spec.Roles[0].Groups, "groups must be updated")
 		})
-		t.Run("will not remove access if AccessRequest in not granted", func(t *testing.T) {
+		t.Run("will not remove access if AccessRequest is not granted yet", func(t *testing.T) {
 			// Given
 			updatedAR := &api.AccessRequest{}
 			updatedProject := &argocd.AppProject{}
@@ -207,7 +207,85 @@ func TestHandlePermission(t *testing.T) {
 			assert.Equal(t, api.InvalidStatus, updatedAR.Status.RequestState)
 			assert.Len(t, updatedProject.Spec.Roles, 0, "project roles must not be changed")
 		})
+		t.Run("will invalidate the AccessRequest if project not found", func(t *testing.T) {
+			// Given
+			updatedAR := &api.AccessRequest{}
+			gr := schema.GroupResource{
+				Group:    "argoproj.io/v1alpha1",
+				Resource: "AppProject",
+			}
+			notFoundError := apierrors.NewNotFound(gr, "Project not found")
+
+			clientMock := mocks.NewMockK8sClient(t)
+			clientMock.EXPECT().
+				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.AppProject")).
+				Return(notFoundError)
+			clientMock.EXPECT().
+				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Application")).
+				RunAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					app := obj.(*argocd.Application)
+					app.Spec.Project = "someProject"
+					return nil
+				})
+			resourceWriterMock := mocks.NewMockSubResourceWriter(t)
+			resourceWriterMock.EXPECT().Update(mock.Anything, mock.AnythingOfType("*v1alpha1.AccessRequest")).
+				RunAndReturn(func(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+					ar := obj.(*api.AccessRequest)
+					updatedAR.Spec = ar.Spec
+					updatedAR.Status = ar.Status
+					return nil
+				}).Maybe()
+			clientMock.EXPECT().Status().Return(resourceWriterMock).Maybe()
+			svc := controller.NewService(clientMock, nil, nil)
+			ar := utils.NewAccessRequest("test", "default", "someApp", "someAppNs", "someRole", "someRoleNs", "")
+			past := &metav1.Time{
+				Time: time.Now().Add(time.Minute * -1),
+			}
+			ar.Status.ExpiresAt = past
+			ar.Status.TargetProject = "someProject"
+
+			// When
+			status, err := svc.HandlePermission(context.Background(), ar)
+
+			// Then
+			assert.NoError(t, err)
+			assert.NotNil(t, status, "status is nil")
+			assert.Equal(t, api.InvalidStatus, status)
+			assert.Equal(t, api.InvalidStatus, updatedAR.Status.RequestState)
+		})
+		t.Run("will return error if fails to retrieve AppProject", func(t *testing.T) {
+			// Given
+			expectedError := errors.New("error retrieving AppProject")
+			clientMock := mocks.NewMockK8sClient(t)
+			clientMock.EXPECT().
+				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.AppProject")).
+				Return(expectedError)
+			clientMock.EXPECT().
+				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Application")).
+				RunAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					app := obj.(*argocd.Application)
+					app.Spec.Project = "someProject"
+					return nil
+				})
+			svc := controller.NewService(clientMock, nil, nil)
+			ar := utils.NewAccessRequest("test", "default", "someApp", "someAppNs", "someRole", "someRoleNs", "")
+			past := &metav1.Time{
+				Time: time.Now().Add(time.Minute * -1),
+			}
+			ar.Status.ExpiresAt = past
+			ar.Status.TargetProject = "someProject"
+
+			// When
+			status, err := svc.HandlePermission(context.Background(), ar)
+
+			// Then
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), expectedError.Error())
+			assert.NotNil(t, status, "status is nil")
+			assert.Empty(t, string(status))
+		})
 	})
+
 	t.Run("will handle application not found", func(t *testing.T) {
 		setup := func(clientMock *mocks.MockK8sClient, roleTemplate *api.RoleTemplate, appProj *argocd.AppProject, updatedProj *argocd.AppProject, updatedAR *api.AccessRequest) {
 			gr := schema.GroupResource{
@@ -405,45 +483,8 @@ func TestHandlePermission(t *testing.T) {
 			assert.Equal(t, api.InvalidStatus, updatedAR.Status.RequestState)
 		})
 	})
+
 	t.Run("will handle access expired", func(t *testing.T) {
-		t.Run("will return error if fails to retrieve AppProject", func(t *testing.T) {
-			// Given
-			expectedError := errors.New("error retrieving AppProject")
-			clientMock := mocks.NewMockK8sClient(t)
-			clientMock.EXPECT().
-				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.AppProject")).
-				Return(expectedError)
-			clientMock.EXPECT().
-				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Application")).
-				RunAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-					app := obj.(*argocd.Application)
-					app.Spec.Project = "someProject"
-					return nil
-				})
-			clientMock.EXPECT().
-				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.RoleTemplate")).
-				RunAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-					rt := obj.(*api.RoleTemplate)
-					rt.Spec.Name = "some-role"
-					return nil
-				})
-			svc := controller.NewService(clientMock, nil, nil)
-			ar := utils.NewAccessRequest("test", "default", "someApp", "someAppNs", "someRole", "someRoleNs", "")
-			past := &metav1.Time{
-				Time: time.Now().Add(time.Minute * -1),
-			}
-			ar.Status.ExpiresAt = past
-			ar.Status.TargetProject = "someProject"
-
-			// When
-			status, err := svc.HandlePermission(context.Background(), ar)
-
-			// Then
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), expectedError.Error())
-			assert.NotNil(t, status, "status is nil")
-			assert.Empty(t, string(status))
-		})
 		t.Run("will return error if fails to remove argocd access", func(t *testing.T) {
 			// Given
 			expectedError := errors.New("error updating AppProject")
@@ -453,8 +494,7 @@ func TestHandlePermission(t *testing.T) {
 				RunAndReturn(func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
 					obj = &argocd.AppProject{}
 					return nil
-				}).
-				Once()
+				})
 			clientMock.EXPECT().
 				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Application")).
 				RunAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
@@ -493,6 +533,7 @@ func TestHandlePermission(t *testing.T) {
 			assert.Empty(t, string(status))
 		})
 	})
+
 	t.Run("will handle plugins", func(t *testing.T) {
 		t.Run("will update the history with the latest plugin message", func(t *testing.T) {
 			// Given
@@ -516,7 +557,6 @@ func TestHandlePermission(t *testing.T) {
 					rt.Spec.Policies = []string{"some-policy"}
 					return nil
 				})
-
 			pluginMock := mocks.NewMockAccessRequester(t)
 			response1 := &plugin.GrantResponse{
 				Status:  plugin.GrantStatusPending,
@@ -549,8 +589,7 @@ func TestHandlePermission(t *testing.T) {
 				RunAndReturn(func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
 					obj = &argocd.AppProject{}
 					return nil
-				}).
-				Once()
+				})
 			clientMock.EXPECT().
 				Patch(mock.Anything, mock.AnythingOfType("*v1alpha1.AppProject"), mock.Anything, mock.Anything).
 				Return(nil).

--- a/internal/controller/service_test.go
+++ b/internal/controller/service_test.go
@@ -47,46 +47,49 @@ func TestHandlePermission(t *testing.T) {
 			},
 		}
 	}
+	setup := func(clientMock *mocks.MockK8sClient, app *argocd.Application, rt *api.RoleTemplate, prj *argocd.AppProject, updatedProj *argocd.AppProject, updatedAR *api.AccessRequest) {
+		clientMock.EXPECT().
+			Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Application")).
+			RunAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if app == nil {
+					return apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io/v1alpha1", Resource: "Application"}, key.Name)
+				}
+				appLocal := obj.(*argocd.Application)
+				appLocal.Spec = app.Spec
+				return nil
+			}).Maybe()
+		clientMock.EXPECT().
+			Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.RoleTemplate")).
+			RunAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				rtLocal := obj.(*api.RoleTemplate)
+				rtLocal.Spec = rt.DeepCopy().Spec
+				return nil
+			}).Maybe()
+		clientMock.EXPECT().
+			Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.AppProject")).
+			RunAndReturn(func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+				prjLocal := obj.(*argocd.AppProject)
+				prjLocal.Spec = prj.DeepCopy().Spec
+				return nil
+			}).Maybe()
+		clientMock.EXPECT().
+			Patch(mock.Anything, mock.AnythingOfType("*v1alpha1.AppProject"), mock.Anything, mock.Anything).
+			RunAndReturn(func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				updatedProj.Spec = obj.(*argocd.AppProject).Spec
+				return nil
+			}).Maybe()
+		resourceWriterMock := mocks.NewMockSubResourceWriter(t)
+		resourceWriterMock.EXPECT().Update(mock.Anything, mock.AnythingOfType("*v1alpha1.AccessRequest")).
+			RunAndReturn(func(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				ar := obj.(*api.AccessRequest)
+				updatedAR.Spec = ar.Spec
+				updatedAR.Status = ar.Status
+				return nil
+			}).Maybe()
+		clientMock.EXPECT().Status().Return(resourceWriterMock).Maybe()
+	}
 
 	t.Run("will validate the project", func(t *testing.T) {
-		setup := func(clientMock *mocks.MockK8sClient, app *argocd.Application, rt *api.RoleTemplate, prj *argocd.AppProject, updatedProj *argocd.AppProject, updatedAR *api.AccessRequest) {
-			clientMock.EXPECT().
-				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Application")).
-				RunAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-					appLocal := obj.(*argocd.Application)
-					appLocal.Spec = app.Spec
-					return nil
-				}).Maybe()
-			clientMock.EXPECT().
-				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.RoleTemplate")).
-				RunAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-					rtLocal := obj.(*api.RoleTemplate)
-					rtLocal.Spec = rt.DeepCopy().Spec
-					return nil
-				}).Maybe()
-			clientMock.EXPECT().
-				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.AppProject")).
-				RunAndReturn(func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
-					prjLocal := obj.(*argocd.AppProject)
-					prjLocal.Spec = prj.DeepCopy().Spec
-					return nil
-				}).Maybe()
-			clientMock.EXPECT().
-				Patch(mock.Anything, mock.AnythingOfType("*v1alpha1.AppProject"), mock.Anything, mock.Anything).
-				RunAndReturn(func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-					updatedProj.Spec = obj.(*argocd.AppProject).Spec
-					return nil
-				}).Maybe()
-			resourceWriterMock := mocks.NewMockSubResourceWriter(t)
-			resourceWriterMock.EXPECT().Update(mock.Anything, mock.AnythingOfType("*v1alpha1.AccessRequest")).
-				RunAndReturn(func(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
-					ar := obj.(*api.AccessRequest)
-					updatedAR.Spec = ar.Spec
-					updatedAR.Status = ar.Status
-					return nil
-				}).Maybe()
-			clientMock.EXPECT().Status().Return(resourceWriterMock).Maybe()
-		}
 		t.Run("will invalidate the AccessRequest if the application project is not set", func(t *testing.T) {
 			// Given
 			updatedAR := &api.AccessRequest{}
@@ -126,7 +129,7 @@ func TestHandlePermission(t *testing.T) {
 			assert.Equal(t, api.InvalidStatus, status, "status must be invalid")
 			assert.Equal(t, api.InvalidStatus, updatedAR.Status.RequestState)
 		})
-		t.Run("will invalidate the AccessRequest and revoke access when application project change", func(t *testing.T) {
+		t.Run("will invalidate the AccessRequest and revoke access when application.spec.project changes", func(t *testing.T) {
 			// Given
 			updatedAR := &api.AccessRequest{}
 			updatedProject := &argocd.AppProject{}
@@ -284,49 +287,60 @@ func TestHandlePermission(t *testing.T) {
 			assert.NotNil(t, status, "status is nil")
 			assert.Empty(t, string(status))
 		})
+		t.Run("will add subject back to role if access is granted and revert tampered project changes", func(t *testing.T) {
+			// Given
+			updatedAR := &api.AccessRequest{}
+			updatedProject := &argocd.AppProject{}
+
+			app := newApp("some-project")
+			rt := newRoleTemplate(api.RoleTemplateSpec{
+				Name:        "some-role-template",
+				Description: "some role description",
+				Policies:    []string{"policy1", "policy2"},
+			})
+			prj := newProject(
+				[]argocd.ProjectRole{
+					{
+						Name:        "ephemeral-some-role-template-someAppNs-someApp",
+						Description: "some role description",
+						Policies:    []string{"policy1", "policy2", "tampered-policy"},
+						JWTTokens: []argocd.JWTToken{
+							{
+								IssuedAt:  0,
+								ExpiresAt: 0,
+								ID:        "tampered-token",
+							},
+						},
+						Groups: []string{"some-user"},
+					},
+				},
+			)
+
+			clientMock := mocks.NewMockK8sClient(t)
+			setup(clientMock, app, rt, prj, updatedProject, updatedAR)
+			ar := utils.NewAccessRequest("test", "default", "someApp", "someAppNs", "someRole", "someRoleNs", "removed-user")
+			ar.Status.TargetProject = "some-project"
+			ar.Status.RequestState = api.GrantedStatus
+			svc := controller.NewService(clientMock, nil, nil)
+
+			// When
+			status, err := svc.HandlePermission(context.Background(), ar)
+
+			// Then
+			assert.NoError(t, err)
+			assert.NotNil(t, status, "status is nil")
+			assert.Equal(t, api.GrantedStatus, status, "status must be granted")
+			assert.Len(t, updatedProject.Spec.Roles, 1, "project roles must not be changed")
+			assert.Len(t, updatedProject.Spec.Roles[0].Groups, 2, "project role groups must contain the removed user")
+			assert.Contains(t, updatedProject.Spec.Roles[0].Groups, "removed-user", "project role groups must contain the removed user")
+			assert.Len(t, updatedProject.Spec.Roles[0].Policies, 2, "project role policies must be reverted to the original policies")
+			assert.Contains(t, updatedProject.Spec.Roles[0].Policies, "policy1", "project role policies must contain policy1")
+			assert.Contains(t, updatedProject.Spec.Roles[0].Policies, "policy2", "project role policies must contain policy2")
+			assert.Len(t, updatedProject.Spec.Roles[0].JWTTokens, 0, "project role JWTTokens must be empty")
+		})
 	})
 
 	t.Run("will handle application not found", func(t *testing.T) {
-		setup := func(clientMock *mocks.MockK8sClient, roleTemplate *api.RoleTemplate, appProj *argocd.AppProject, updatedProj *argocd.AppProject, updatedAR *api.AccessRequest) {
-			gr := schema.GroupResource{
-				Group:    "argoproj.io/v1alpha1",
-				Resource: "Application",
-			}
-			notFoundErr := apierrors.NewNotFound(gr, "someApp")
-			clientMock.EXPECT().
-				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Application")).
-				Return(notFoundErr).Maybe()
-			clientMock.EXPECT().
-				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.RoleTemplate")).
-				RunAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-					rt := obj.(*api.RoleTemplate)
-					rt.Spec = roleTemplate.DeepCopy().Spec
-					return nil
-				}).Maybe()
-			clientMock.EXPECT().
-				Get(mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.AppProject")).
-				RunAndReturn(func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
-					prj := obj.(*argocd.AppProject)
-					prj.Spec = appProj.DeepCopy().Spec
-					return nil
-				}).Maybe()
-			clientMock.EXPECT().
-				Patch(mock.Anything, mock.AnythingOfType("*v1alpha1.AppProject"), mock.Anything, mock.Anything).
-				RunAndReturn(func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-					updatedProj.Spec = obj.(*argocd.AppProject).Spec
-					return nil
-				}).Maybe()
-			resourceWriterMock := mocks.NewMockSubResourceWriter(t)
-			resourceWriterMock.EXPECT().Update(mock.Anything, mock.AnythingOfType("*v1alpha1.AccessRequest")).
-				RunAndReturn(func(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
-					ar := obj.(*api.AccessRequest)
-					updatedAR.Spec = ar.Spec
-					updatedAR.Status = ar.Status
-					return nil
-				}).Maybe()
-			clientMock.EXPECT().Status().Return(resourceWriterMock).Maybe()
-		}
-
 		t.Run("will remove Argo CD permissions successfully", func(t *testing.T) {
 			// Given
 			clientMock := mocks.NewMockK8sClient(t)
@@ -356,7 +370,7 @@ func TestHandlePermission(t *testing.T) {
 			}
 			updatedProject := &argocd.AppProject{}
 			updatedAR := &api.AccessRequest{}
-			setup(clientMock, roleTemplate, currentProj, updatedProject, updatedAR)
+			setup(clientMock, nil, roleTemplate, currentProj, updatedProject, updatedAR)
 
 			svc := controller.NewService(clientMock, nil, nil)
 			ar := utils.NewAccessRequest("test", "default", "someApp", "someAppNs", "someRole", "someRoleNs", "user-to-be-removed")
@@ -409,7 +423,7 @@ func TestHandlePermission(t *testing.T) {
 			}
 			updatedProject := &argocd.AppProject{}
 			updatedAR := &api.AccessRequest{}
-			setup(clientMock, roleTemplate, tamperedProj, updatedProject, updatedAR)
+			setup(clientMock, nil, roleTemplate, tamperedProj, updatedProject, updatedAR)
 
 			svc := controller.NewService(clientMock, nil, nil)
 			ar := utils.NewAccessRequest("test", "default", "someApp", "someAppNs", "someRole", "someRoleNs", "another-user")
@@ -468,7 +482,7 @@ func TestHandlePermission(t *testing.T) {
 			}
 			updatedProject := &argocd.AppProject{}
 			updatedAR := &api.AccessRequest{}
-			setup(clientMock, roleTemplate, currentProj, updatedProject, updatedAR)
+			setup(clientMock, nil, roleTemplate, currentProj, updatedProject, updatedAR)
 
 			svc := controller.NewService(clientMock, nil, nil)
 			ar := utils.NewAccessRequest("test", "default", "someApp", "someAppNs", "someRole", "someRoleNs", "user-to-be-removed")


### PR DESCRIPTION
Will handle project changes in the Application resource. Associated non concluded AccessRequests will be invalidated and Argo CD access revoked.

- Introduce ProjectChangedPredicate and ApplicationChangedPredicate to
trigger reconciliation only when relevant fields in AppProject or
Application resources change.
- Add ProjectChangeShouldTriggerReconcile
function to compare AppProject roles, policies, JWT tokens, and groups.
- Update controller setup to use these predicates for efficient watching.
- Add unit tests for ProjectChangeShouldTriggerReconcile logic.

Signed-off-by: Leonardo Luz Almeida <leonardo_almeida@intuit.com>
