### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,11 +4,17 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: Continuous Integration
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - name: Set up Go
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # pin@v5
@@ -19,6 +25,8 @@ jobs:
             go.sum
       - name: Checkout Repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        with:
+          persist-credentials: false
       - name: Get dependencies
         run: go mod download
       - name: Build
@@ -26,7 +34,7 @@ jobs:
       - name: Run Unit-Tests
         run: make test
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4
         with:
           name: code-coverage
           path: cover.out
@@ -34,11 +42,15 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     needs: ci
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        with:
+          persist-credentials: false
       - name: Download Coverage Report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # pin@v4
         with:
           name: code-coverage
       - name: Print Coverage

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,21 +14,28 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest
     if: github.repository == 'argoproj-labs/argocd-ephemeral-access'
     name: Release
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # pin@v4
         with:
           go-version: 1.24
+          cache: false
 
       - name: Docker Login in quay.io
         uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # pin@v1


### PR DESCRIPTION
Security hardening for both workflows. No behavior change.

- Workflow- and job-level `permissions` set to least privilege. `contents: write` only on the release job.
- `persist-credentials: false` on every `actions/checkout` so the default `GITHUB_TOKEN` doesn't linger in `.git/config` for later steps.
- `cache: false` on `setup-go` in `release.yaml`. Release runs on tag push with write perms — Go module cache is a poisoning vector there.
- `actions/upload-artifact` and `actions/download-artifact` pinned to commit SHAs.