### PR TITLE
fix: externalize react/jsx-runtime for React 19 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ associated with an `AppProjects` different than `default`.
 The Ephemeral Access extension requires Argo CD v2.13.0+ to be
 installed.
 
+Starting with `v1.1.0`, this extension requires **Argo CD v3.5 or
+later**. For Argo CD versions earlier than v3.5, use extension version
+`v1.0.x`.
+
 ## Installation
 
 The ephemeral-access functionality is provided by the following

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -20,6 +20,7 @@ const config = {
   externals: {
     react: "React",
     "react-dom": "ReactDOM",
+    "react/jsx-runtime": "ReactJSXRuntime",
     moment: "Moment",
   },
   optimization: {


### PR DESCRIPTION
## Problem

When ArgoCD is upgraded to use React 19, this extension fails to load with:

    TypeError: Cannot read properties of undefined (reading 'ReactCurrentOwner')

`react` and `react-dom` are already externalized, but `react/jsx-runtime` is
not. Dependencies such as `antd` import `react/jsx-runtime` directly, causing
a bundled copy to be included. That bundled copy internally reads:

    React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner

In React 19, `__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` was renamed
and `ReactCurrentOwner` no longer exists on it, causing the crash.

## Fix

Externalize `react/jsx-runtime`. ArgoCD core already exposes
`window.ReactJSXRuntime` as a global, so all JSX runtime imports will resolve
to the host app's React 19 instance rather than a bundled React 18 copy.

## Changes

- `ui/webpack.config.js`: add `'react/jsx-runtime': 'ReactJSXRuntime'` to
  `externals`