### PR TITLE
fix: relay plugin logs with a correct level-aware introducing a zap-hclog adapter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ FROM golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
+# GOPROXY can be overridden at build time to use a private module proxy, e.g.
+# for builds behind a firewall that blocks the public proxy.golang.org.
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY:-https://proxy.golang.org,direct}
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-controller: COMMAND=./bin/ephemeral-access && sh -c "EPHEMERAL_CONTROLLER_HEALTH_PROBE_ADDR=:8989 EPHEMERAL_CONTROLLER_PORT=9091 $COMMAND controller"
+controller: COMMAND=./bin/ephemeral-access && sh -c "EPHEMERAL_LOG_LEVEL=debug EPHEMERAL_CONTROLLER_HEALTH_PROBE_ADDR=:8989 EPHEMERAL_CONTROLLER_PORT=9091 $COMMAND controller"
 backend: COMMAND=./bin/ephemeral-access && sh -c "EPHEMERAL_BACKEND_NAMESPACE=ephemeral KUBECONFIG=${KUBECONFIG:-~/.kube/config} $COMMAND backend"
 tracing: sh -c "docker run --rm --name ephemeral-access-jaeger -p 16686:16686 -p 4317:4317 -p 4318:4318 jaegertracing/all-in-one:latest"

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -23,7 +23,6 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
-	"go.uber.org/zap"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	goPlugin "github.com/hashicorp/go-plugin"
@@ -141,7 +140,7 @@ func run(cmd *cobra.Command, args []string) error {
 	var accessRequester plugin.AccessRequester
 	// register the plugin when the path is provided
 	if config.PluginPath() != "" {
-		accessRequester, err = initPlugin(config.PluginPath(), zaplogger)
+		accessRequester, err = initPlugin(config.PluginPath(), level, format)
 		if err != nil {
 			return fmt.Errorf("plugin initialization error: %w", err)
 		}
@@ -178,11 +177,12 @@ func run(cmd *cobra.Command, args []string) error {
 }
 
 // initPlugin will initialize the AccessRequester plugin from the binary
-// provided in the given path.
-func initPlugin(path string, logger *zap.Logger) (plugin.AccessRequester, error) {
+// provided in the given path. The given level and format are used to configure
+// the host side logger that relays the plugin subprocess logs.
+func initPlugin(path string, level log.LogLevel, format log.LogFormat) (plugin.AccessRequester, error) {
 	setupLog.Info("Initializing AccessRequester plugin...", "path", path)
 
-	pluginLog, err := log.NewPluginLogger(logger)
+	pluginLog, err := log.NewPluginLogger(log.WithLevel(level), log.WithFormat(format))
 	if err != nil {
 		return nil, fmt.Errorf("error building plugin logger: %w", err)
 	}

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -23,6 +23,7 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
+	"go.uber.org/zap"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	goPlugin "github.com/hashicorp/go-plugin"
@@ -140,7 +141,7 @@ func run(cmd *cobra.Command, args []string) error {
 	var accessRequester plugin.AccessRequester
 	// register the plugin when the path is provided
 	if config.PluginPath() != "" {
-		accessRequester, err = initPlugin(config.PluginPath(), level, format)
+		accessRequester, err = initPlugin(config.PluginPath(), zaplogger)
 		if err != nil {
 			return fmt.Errorf("plugin initialization error: %w", err)
 		}
@@ -177,14 +178,15 @@ func run(cmd *cobra.Command, args []string) error {
 }
 
 // initPlugin will initialize the AccessRequester plugin from the binary
-// provided in the given path. The given level and format are used to configure
-// the host side logger that relays the plugin subprocess logs.
-func initPlugin(path string, level log.LogLevel, format log.LogFormat) (plugin.AccessRequester, error) {
+// provided in the given path. The given zap logger is wrapped to build the host
+// side logger that relays the plugin subprocess logs into the controller's log
+// stream, keeping their format consistent with the controller's own logs.
+func initPlugin(path string, zaplogger *zap.Logger) (plugin.AccessRequester, error) {
 	setupLog.Info("Initializing AccessRequester plugin...", "path", path)
 
-	pluginLog, err := log.NewPluginLogger(log.WithLevel(level), log.WithFormat(format))
+	pluginLog, err := log.NewPluginHostLogger(zaplogger)
 	if err != nil {
-		return nil, fmt.Errorf("error building plugin logger: %w", err)
+		return nil, fmt.Errorf("error building plugin host logger: %w", err)
 	}
 	cliConfig := plugin.NewClientConfig(path, pluginLog)
 	client := goPlugin.NewClient(cliConfig)

--- a/examples/plugin/cmd/main.go
+++ b/examples/plugin/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	argocd "github.com/argoproj-labs/argocd-ephemeral-access/api/argoproj/v1alpha1"
 	api "github.com/argoproj-labs/argocd-ephemeral-access/api/ephemeral-access/v1alpha1"
@@ -74,9 +75,18 @@ func (p *SomePlugin) RevokeAccess(ar *api.AccessRequest, app *argocd.Application
 // main must be defined as it is the plugin entrypoint. It will be automatically called
 // by the EphemeralAccess controller.
 func main() {
-	// NewPluginLogger will return a logger that will respect the same level and format
-	// defined to the EphemeralAccess controller.
-	logger, err := log.NewPluginLogger()
+	// The EphemeralAccess controller propagates its log level and format to the
+	// plugin process via the EPHEMERAL_LOG_LEVEL and EPHEMERAL_LOG_FORMAT env
+	// variables. Building the plugin logger from them makes its output respect
+	// the same level and format defined for the controller.
+	opts := []log.Opts{}
+	if logLevel := os.Getenv(log.EphemeralLogLevel); logLevel != "" {
+		opts = append(opts, log.WithLevel(log.LogLevel(logLevel)))
+	}
+	if logFormat := os.Getenv(log.EphemeralLogFormat); logFormat != "" {
+		opts = append(opts, log.WithFormat(log.LogFormat(logFormat)))
+	}
+	logger, err := log.NewPluginLogger(opts...)
 	if err != nil {
 		panic(fmt.Sprintf("Error creating plugin logger: %s", err))
 	}

--- a/examples/plugin/cmd/main.go
+++ b/examples/plugin/cmd/main.go
@@ -79,7 +79,12 @@ func main() {
 	// plugin process via the EPHEMERAL_LOG_LEVEL and EPHEMERAL_LOG_FORMAT env
 	// variables. Building the plugin logger from them makes its output respect
 	// the same level and format defined for the controller.
-	opts := []log.Opts{}
+	opts := []log.Opts{
+		// The name is relayed to the controller log stream (as the hclog
+		// "@module" field) so this plugin's entries can be identified there.
+		// Set it to a value that identifies your plugin.
+		log.WithName("some-plugin"),
+	}
 	if logLevel := os.Getenv(log.EphemeralLogLevel); logLevel != "" {
 		opts = append(opts, log.WithLevel(log.LogLevel(logLevel)))
 	}

--- a/examples/plugin/cmd/main.go
+++ b/examples/plugin/cmd/main.go
@@ -75,10 +75,12 @@ func (p *SomePlugin) RevokeAccess(ar *api.AccessRequest, app *argocd.Application
 // main must be defined as it is the plugin entrypoint. It will be automatically called
 // by the EphemeralAccess controller.
 func main() {
-	// The EphemeralAccess controller propagates its log level and format to the
-	// plugin process via the EPHEMERAL_LOG_LEVEL and EPHEMERAL_LOG_FORMAT env
-	// variables. Building the plugin logger from them makes its output respect
-	// the same level and format defined for the controller.
+	// The EphemeralAccess controller propagates its log level to the plugin
+	// process via the EPHEMERAL_LOG_LEVEL env variable so the plugin respects
+	// the same level defined for the controller. The log format is not
+	// configurable here: NewPluginLogger always emits hclog JSON so the
+	// go-plugin host can parse each entry and relay it into the controller log
+	// stream, which renders it in the controller's configured format.
 	opts := []log.Opts{
 		// The name is relayed to the controller log stream (as the hclog
 		// "@module" field) so this plugin's entries can be identified there.
@@ -88,10 +90,7 @@ func main() {
 	if logLevel := os.Getenv(log.EphemeralLogLevel); logLevel != "" {
 		opts = append(opts, log.WithLevel(log.LogLevel(logLevel)))
 	}
-	if logFormat := os.Getenv(log.EphemeralLogFormat); logFormat != "" {
-		opts = append(opts, log.WithFormat(log.LogFormat(logFormat)))
-	}
-	logger, err := log.NewPluginLogger(opts...)
+	logger, err := log.NewPluginLoggerWithOpts(opts...)
 	if err != nil {
 		panic(fmt.Sprintf("Error creating plugin logger: %s", err))
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/sethvargo/go-envconfig v1.3.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
-	github.com/zaffka/zap-to-hclog v0.10.6
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.66.0
 	go.opentelemetry.io/contrib/propagators/autoprop v0.66.0
 	go.opentelemetry.io/otel v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,6 @@ github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/zaffka/zap-to-hclog v0.10.6 h1:dNxbL5drL6sVUDHtCMbokJLWrYn5wSKAWTXjgWFadx0=
-github.com/zaffka/zap-to-hclog v0.10.6/go.mod h1:wLqRe/Fa1MkfUY9EtnCDiz2CqhTPNZPh0/pRE9lLi04=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.66.0 h1:PnV4kVnw0zOmwwFkAzCN5O07fw1YOIQor120zrh0AVo=

--- a/pkg/log/hclog_adapter.go
+++ b/pkg/log/hclog_adapter.go
@@ -1,0 +1,166 @@
+package log
+
+import (
+	"io"
+	stdlog "log"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// zapHCLogAdapter adapts a *zap.Logger to the hclog.Logger interface. It is used
+// on the controller (host) side to relay the plugin subprocess logs into the
+// controller's log stream so that the relayed entries are encoded exactly like
+// the controller's own logs.
+//
+// Unlike a generic wrapper, the level query methods (IsTrace, IsDebug, ...) and
+// GetLevel consult the underlying zap logger so that the go-plugin host observes
+// the level that is actually in effect. SetLevel is intentionally a no-op: the
+// zap logger owns the level and it is configured once from the controller
+// settings.
+type zapHCLogAdapter struct {
+	zap  *zap.Logger
+	name string
+}
+
+// newZapHCLogAdapter wraps the given zap logger as an hclog.Logger.
+func newZapHCLogAdapter(z *zap.Logger) hclog.Logger {
+	return &zapHCLogAdapter{zap: z}
+}
+
+// hclogToZapLevel maps an hclog level to the corresponding zap level. hclog has
+// a Trace level that zap does not, so it is mapped to DebugLevel.
+func hclogToZapLevel(level hclog.Level) zapcore.Level {
+	switch level {
+	case hclog.Trace, hclog.Debug:
+		return zapcore.DebugLevel
+	case hclog.Info, hclog.NoLevel, hclog.DefaultLevel:
+		return zapcore.InfoLevel
+	case hclog.Warn:
+		return zapcore.WarnLevel
+	case hclog.Error:
+		return zapcore.ErrorLevel
+	default:
+		return zapcore.InfoLevel
+	}
+}
+
+// zapToHCLogLevel maps a zap level to the corresponding hclog level.
+func zapToHCLogLevel(level zapcore.Level) hclog.Level {
+	switch level {
+	case zapcore.DebugLevel:
+		return hclog.Debug
+	case zapcore.InfoLevel:
+		return hclog.Info
+	case zapcore.WarnLevel:
+		return hclog.Warn
+	case zapcore.ErrorLevel, zapcore.DPanicLevel, zapcore.PanicLevel, zapcore.FatalLevel:
+		return hclog.Error
+	default:
+		return hclog.Info
+	}
+}
+
+// toZapFields converts hclog's variadic key/value args into zap fields. Keys
+// that are not strings fall back to a positional field name so no argument is
+// silently dropped.
+func toZapFields(args ...interface{}) []zapcore.Field {
+	fields := make([]zapcore.Field, 0, (len(args)+1)/2)
+	for i := 0; i < len(args); i += 2 {
+		if i+1 >= len(args) {
+			// odd trailing arg with no value
+			fields = append(fields, zap.Any(hclog.MissingKey, args[i]))
+			break
+		}
+		key, ok := args[i].(string)
+		if !ok {
+			key = hclog.MissingKey
+			fields = append(fields, zap.Any(key, args[i]))
+			continue
+		}
+		fields = append(fields, zap.Any(key, args[i+1]))
+	}
+	return fields
+}
+
+func (a *zapHCLogAdapter) Log(level hclog.Level, msg string, args ...interface{}) {
+	switch level {
+	case hclog.Trace, hclog.Debug:
+		a.Debug(msg, args...)
+	case hclog.Warn:
+		a.Warn(msg, args...)
+	case hclog.Error:
+		a.Error(msg, args...)
+	default:
+		a.Info(msg, args...)
+	}
+}
+
+func (a *zapHCLogAdapter) Trace(msg string, args ...interface{}) {
+	a.zap.Debug(msg, toZapFields(args...)...)
+}
+
+func (a *zapHCLogAdapter) Debug(msg string, args ...interface{}) {
+	a.zap.Debug(msg, toZapFields(args...)...)
+}
+
+func (a *zapHCLogAdapter) Info(msg string, args ...interface{}) {
+	a.zap.Info(msg, toZapFields(args...)...)
+}
+
+func (a *zapHCLogAdapter) Warn(msg string, args ...interface{}) {
+	a.zap.Warn(msg, toZapFields(args...)...)
+}
+
+func (a *zapHCLogAdapter) Error(msg string, args ...interface{}) {
+	a.zap.Error(msg, toZapFields(args...)...)
+}
+
+// enabled reports whether the underlying zap logger emits at the given hclog
+// level.
+func (a *zapHCLogAdapter) enabled(level hclog.Level) bool {
+	return a.zap.Core().Enabled(hclogToZapLevel(level))
+}
+
+func (a *zapHCLogAdapter) IsTrace() bool { return a.enabled(hclog.Trace) }
+func (a *zapHCLogAdapter) IsDebug() bool { return a.enabled(hclog.Debug) }
+func (a *zapHCLogAdapter) IsInfo() bool  { return a.enabled(hclog.Info) }
+func (a *zapHCLogAdapter) IsWarn() bool  { return a.enabled(hclog.Warn) }
+func (a *zapHCLogAdapter) IsError() bool { return a.enabled(hclog.Error) }
+
+func (a *zapHCLogAdapter) ImpliedArgs() []interface{} { return nil }
+
+func (a *zapHCLogAdapter) With(args ...interface{}) hclog.Logger {
+	return &zapHCLogAdapter{zap: a.zap.With(toZapFields(args...)...), name: a.name}
+}
+
+func (a *zapHCLogAdapter) Name() string { return a.name }
+
+func (a *zapHCLogAdapter) Named(name string) hclog.Logger {
+	newName := name
+	if a.name != "" {
+		newName = a.name + "." + name
+	}
+	return &zapHCLogAdapter{zap: a.zap.Named(name), name: newName}
+}
+
+func (a *zapHCLogAdapter) ResetNamed(name string) hclog.Logger {
+	return &zapHCLogAdapter{zap: a.zap.Named(name), name: name}
+}
+
+// SetLevel is a no-op. The level is owned by the underlying zap logger, which is
+// configured once from the controller settings.
+func (a *zapHCLogAdapter) SetLevel(level hclog.Level) {}
+
+func (a *zapHCLogAdapter) GetLevel() hclog.Level {
+	return zapToHCLogLevel(a.zap.Level())
+}
+
+func (a *zapHCLogAdapter) StandardLogger(opts *hclog.StandardLoggerOptions) *stdlog.Logger {
+	return stdlog.New(a.StandardWriter(opts), "", 0)
+}
+
+func (a *zapHCLogAdapter) StandardWriter(opts *hclog.StandardLoggerOptions) io.Writer {
+	return hclog.DefaultOutput
+}

--- a/pkg/log/hclog_adapter.go
+++ b/pkg/log/hclog_adapter.go
@@ -29,6 +29,14 @@ func newZapHCLogAdapter(z *zap.Logger) hclog.Logger {
 	return &zapHCLogAdapter{zap: z}
 }
 
+// relayedTimestampKey is the key under which the go-plugin host re-injects the
+// plugin entry's original timestamp as a key/value pair when relaying it to the
+// host logger (see go-plugin client.go logStderr:
+// out = append(out, "timestamp", entry.Timestamp...)). The zap encoder already
+// stamps its own time field, so this relayed key is dropped to avoid a
+// duplicate timestamp in the controller log stream.
+const relayedTimestampKey = "timestamp"
+
 // hclogToZapLevel maps an hclog level to the corresponding zap level. hclog has
 // a Trace level that zap does not, so it is mapped to DebugLevel.
 func hclogToZapLevel(level hclog.Level) zapcore.Level {
@@ -77,6 +85,11 @@ func toZapFields(args ...interface{}) []zapcore.Field {
 		if !ok {
 			key = hclog.MissingKey
 			fields = append(fields, zap.Any(key, args[i]))
+			continue
+		}
+		// Drop the timestamp the go-plugin host re-injects; the zap encoder
+		// already emits its own time field. See relayedTimestampKey.
+		if key == relayedTimestampKey {
 			continue
 		}
 		fields = append(fields, zap.Any(key, args[i+1]))

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -224,28 +224,63 @@ const (
 )
 
 // NewPluginLogger will initialize a native hclog.Logger to be used in
-// ephemeral-access plugins. It builds the logger so that its output is
-// formatted as hclog expects, which allows the go-plugin host to correctly
-// parse the log level and message of each entry relayed from the plugin
-// subprocess. The log level and format are defined by the provided opts,
-// defaulting to InfoLevel and TextFormat when not set. Callers running in the
-// plugin subprocess (where the controller configs are not available) should
-// derive the opts from the EPHEMERAL_LOG_LEVEL and EPHEMERAL_LOG_FORMAT
-// environment variables, which the controller propagates to the plugin process.
+// ephemeral-access plugins, deriving the log level from the provided zap.Logger
+// and emitting hclog JSON.
+//
+// Deprecated: use NewPluginLoggerWithOpts, which does not require a zap.Logger
+// and allows configuring the logger name (relayed to the controller as the
+// hclog "@module" field). This function is retained for backward compatibility;
+// it only reads the level from the given logger and otherwise ignores it (in
+// particular its encoder/format), because the plugin->host log channel requires
+// hclog JSON. See NewPluginLoggerWithOpts for details. Returns an error if the
+// provided logger is nil.
+func NewPluginLogger(logger *zap.Logger) (hclog.Logger, error) {
+	if logger == nil {
+		return nil, fmt.Errorf("no logger provided to NewPluginLogger")
+	}
+	return newPluginLogger(WithLevel(LogLevel(logger.Level().String()))), nil
+}
+
+// NewPluginLoggerWithOpts will initialize a native hclog.Logger to be used in
+// ephemeral-access plugins. The log level is defined by the provided opts,
+// defaulting to InfoLevel when not set. Callers running in the plugin
+// subprocess (where the controller configs are not available) should derive the
+// level from the EPHEMERAL_LOG_LEVEL environment variable, which the controller
+// propagates to the plugin process.
+//
+// The output is always encoded as hclog JSON regardless of any WithFormat
+// option. The plugin->host log channel is an internal protocol that only the
+// hclog JSON format can carry losslessly: it lets the go-plugin host parse the
+// level and message of each relayed entry and re-emit them through the
+// controller logger. With text output the host cannot parse the entry and
+// relays the whole line into the host "msg" field. The format the operator sees
+// is therefore defined by the controller logger, not by this plugin logger.
 //
 // The logger name defaults to "plugin" and can be set with WithName. The name
 // is emitted as the hclog "@module" field of each entry, which the go-plugin
 // host relays into the controller log stream, allowing a plugin to identify
 // itself in that stream.
-func NewPluginLogger(opts ...Opts) (hclog.Logger, error) {
+func NewPluginLoggerWithOpts(opts ...Opts) (hclog.Logger, error) {
+	return newPluginLogger(opts...), nil
+}
+
+// newPluginLogger builds the native hclog.Logger shared by the exported plugin
+// logger constructors.
+func newPluginLogger(opts ...Opts) hclog.Logger {
 	cfg := logConfig(opts...)
-	jsonFormat := cfg.logFormat == JsonFormat
 	return hclog.New(&hclog.LoggerOptions{
-		Name:            cfg.logName,
-		Level:           hclog.LevelFromString(string(cfg.logLevel)),
-		JSONFormat:      jsonFormat,
+		Name:  cfg.logName,
+		Level: hclog.LevelFromString(string(cfg.logLevel)),
+		// Always JSON: the go-plugin host requires hclog JSON to parse each
+		// relayed entry. See NewPluginLoggerWithOpts for details.
+		JSONFormat: true,
+		// Do not include the source location. When true, hclog adds an
+		// "@caller" file:line field resolved via runtime.Caller. That location
+		// would point at this logging package rather than the plugin call site,
+		// so it is misleading, and it adds a per-log runtime.Caller cost for no
+		// benefit once the entry is relayed to the controller.
 		IncludeLocation: false,
-	}), nil
+	})
 }
 
 // NewPluginHostLogger builds the host side hclog.Logger that the go-plugin host

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -44,6 +44,7 @@ func (l LogFormat) String() string {
 type LogConfig struct {
 	logLevel  LogLevel
 	logFormat LogFormat
+	logName   string
 }
 
 type Opts func(*LogConfig)
@@ -57,6 +58,15 @@ func WithLevel(level LogLevel) Opts {
 func WithFormat(format LogFormat) Opts {
 	return func(c *LogConfig) {
 		c.logFormat = format
+	}
+}
+
+// WithName sets the logger name. For plugin loggers this name is emitted as the
+// hclog "@module" field of each entry, which the go-plugin host relays into the
+// controller log stream, allowing a plugin to identify itself in that stream.
+func WithName(name string) Opts {
+	return func(c *LogConfig) {
+		c.logName = name
 	}
 }
 
@@ -200,6 +210,7 @@ func logConfig(opts ...Opts) *LogConfig {
 	cfg := &LogConfig{
 		logLevel:  InfoLevel,
 		logFormat: TextFormat,
+		logName:   "plugin",
 	}
 	for _, opt := range opts {
 		opt(cfg)
@@ -221,11 +232,16 @@ const (
 // plugin subprocess (where the controller configs are not available) should
 // derive the opts from the EPHEMERAL_LOG_LEVEL and EPHEMERAL_LOG_FORMAT
 // environment variables, which the controller propagates to the plugin process.
+//
+// The logger name defaults to "plugin" and can be set with WithName. The name
+// is emitted as the hclog "@module" field of each entry, which the go-plugin
+// host relays into the controller log stream, allowing a plugin to identify
+// itself in that stream.
 func NewPluginLogger(opts ...Opts) (hclog.Logger, error) {
 	cfg := logConfig(opts...)
 	jsonFormat := cfg.logFormat == JsonFormat
 	return hclog.New(&hclog.LoggerOptions{
-		Name:            "plugin",
+		Name:            cfg.logName,
 		Level:           hclog.LevelFromString(string(cfg.logLevel)),
 		JSONFormat:      jsonFormat,
 		IncludeLocation: false,

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -293,12 +293,17 @@ func newPluginLogger(opts ...Opts) hclog.Logger {
 // (the plugin's own emitter), whose output must remain native hclog so the host
 // can correctly parse the level and message of each relayed entry.
 //
+// The returned logger is intentionally not named: the go-plugin host already
+// names the relay logger after the plugin binary (filepath.Base of the plugin
+// path). Naming it here too would prepend a redundant segment (e.g.
+// "plugin.plugin") to every relayed entry.
+//
 // It returns an error if the provided logger is nil.
 func NewPluginHostLogger(logger *zap.Logger) (hclog.Logger, error) {
 	if logger == nil {
 		return nil, fmt.Errorf("no logger provided to NewPluginHostLogger")
 	}
-	return newZapHCLogAdapter(logger).Named("plugin"), nil
+	return newZapHCLogAdapter(logger), nil
 }
 
 // NewAppLogger creates a new logr.Logger instance using the provided zap.Logger.

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-logr/zapr"
 	hclog "github.com/hashicorp/go-hclog"
 
-	zaptohclog "github.com/zaffka/zap-to-hclog"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	k8slog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -213,20 +212,24 @@ const (
 	EphemeralLogFormat = "EPHEMERAL_LOG_FORMAT"
 )
 
-// NewPluginLogger creates a new hclog.Logger instance wrapped around the provided zap.Logger.
-// It returns an error if the provided logger is nil.
-//
-// Parameters:
-//   - logger: A *zap.Logger instance to be wrapped.
-//
-// Returns:
-//   - hclog.Logger: The wrapped logger instance.
-//   - error: An error if the logger is nil.
-func NewPluginLogger(logger *zap.Logger) (hclog.Logger, error) {
-	if logger == nil {
-		return nil, fmt.Errorf("No logger provided to NewPluginLogger")
-	}
-	return zaptohclog.Wrap(logger).Named("plugin"), nil
+// NewPluginLogger will initialize a native hclog.Logger to be used in
+// ephemeral-access plugins. It builds the logger so that its output is
+// formatted as hclog expects, which allows the go-plugin host to correctly
+// parse the log level and message of each entry relayed from the plugin
+// subprocess. The log level and format are defined by the provided opts,
+// defaulting to InfoLevel and TextFormat when not set. Callers running in the
+// plugin subprocess (where the controller configs are not available) should
+// derive the opts from the EPHEMERAL_LOG_LEVEL and EPHEMERAL_LOG_FORMAT
+// environment variables, which the controller propagates to the plugin process.
+func NewPluginLogger(opts ...Opts) (hclog.Logger, error) {
+	cfg := logConfig(opts...)
+	jsonFormat := cfg.logFormat == JsonFormat
+	return hclog.New(&hclog.LoggerOptions{
+		Name:            "plugin",
+		Level:           hclog.LevelFromString(string(cfg.logLevel)),
+		JSONFormat:      jsonFormat,
+		IncludeLocation: false,
+	}), nil
 }
 
 // NewAppLogger creates a new logr.Logger instance using the provided zap.Logger.

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -232,6 +232,24 @@ func NewPluginLogger(opts ...Opts) (hclog.Logger, error) {
 	}), nil
 }
 
+// NewPluginHostLogger builds the host side hclog.Logger that the go-plugin host
+// uses to relay the plugin subprocess logs into the controller's log stream. It
+// wraps the provided zap.Logger so that the relayed entries are encoded exactly
+// like the controller's own logs, keeping the aggregated output consistent.
+//
+// This logger only produces output on the host and never crosses the plugin RPC
+// boundary, so wrapping zap here is safe. This is in contrast to NewPluginLogger
+// (the plugin's own emitter), whose output must remain native hclog so the host
+// can correctly parse the level and message of each relayed entry.
+//
+// It returns an error if the provided logger is nil.
+func NewPluginHostLogger(logger *zap.Logger) (hclog.Logger, error) {
+	if logger == nil {
+		return nil, fmt.Errorf("no logger provided to NewPluginHostLogger")
+	}
+	return newZapHCLogAdapter(logger).Named("plugin"), nil
+}
+
 // NewAppLogger creates a new logr.Logger instance using the provided zap.Logger.
 // It returns an error if the provided logger is nil.
 //

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -182,17 +182,18 @@ func TestPluginHostLogger(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, logger)
 	})
-	t.Run("will name the logger plugin", func(t *testing.T) {
+	t.Run("will not name the logger so the host can name it after the plugin", func(t *testing.T) {
 		// Given
 		zl := zaptest.NewLogger(t)
 
 		// When
 		logger, err := log.NewPluginHostLogger(zl)
 
-		// Then
+		// Then the logger is unnamed; the go-plugin host names it after the
+		// plugin binary, so naming it here would produce a redundant segment.
 		assert.NoError(t, err)
 		assert.NotNil(t, logger)
-		assert.Equal(t, "plugin", logger.Name())
+		assert.Equal(t, "", logger.Name())
 	})
 	t.Run("will report level from the wrapped zap logger", func(t *testing.T) {
 		// Given a zap logger enabled at debug level
@@ -250,6 +251,31 @@ func TestPluginHostLogger(t *testing.T) {
 		require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
 		assert.Equal(t, "relayed message", entry["msg"])
 		assert.Equal(t, "value", entry["key"])
+	})
+	t.Run("will drop the timestamp re-injected by the go-plugin host", func(t *testing.T) {
+		// Given a zap logger writing JSON to a buffer
+		var buf bytes.Buffer
+		core := zapcore.NewCore(
+			zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+			zapcore.AddSync(&buf),
+			zapcore.InfoLevel,
+		)
+		zl := zap.New(core)
+		logger, err := log.NewPluginHostLogger(zl)
+		require.NoError(t, err)
+
+		// When the host relays an entry, the go-plugin host appends a
+		// "timestamp" key/value pair carrying the plugin's original time.
+		logger.Info("relayed message", "timestamp", "2026-07-28T14:20:28.843Z", "key", "value")
+
+		// Then the relayed timestamp is dropped (zap already emits its own "ts"
+		// time field), while other key/value pairs are preserved.
+		var entry map[string]interface{}
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+		assert.Equal(t, "relayed message", entry["msg"])
+		assert.Equal(t, "value", entry["key"])
+		assert.NotContains(t, entry, "timestamp")
+		assert.Contains(t, entry, "ts")
 	})
 }
 

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -71,6 +71,86 @@ func TestPluginLogger(t *testing.T) {
 	})
 }
 
+func TestPluginHostLogger(t *testing.T) {
+	t.Run("will return error when logger is nil", func(t *testing.T) {
+		// When
+		logger, err := log.NewPluginHostLogger(nil)
+
+		// Then
+		assert.Error(t, err)
+		assert.Nil(t, logger)
+	})
+	t.Run("will name the logger plugin", func(t *testing.T) {
+		// Given
+		zl := zaptest.NewLogger(t)
+
+		// When
+		logger, err := log.NewPluginHostLogger(zl)
+
+		// Then
+		assert.NoError(t, err)
+		assert.NotNil(t, logger)
+		assert.Equal(t, "plugin", logger.Name())
+	})
+	t.Run("will report level from the wrapped zap logger", func(t *testing.T) {
+		// Given a zap logger enabled at debug level
+		core := zapcore.NewCore(
+			zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+			zapcore.AddSync(io.Discard),
+			zapcore.DebugLevel,
+		)
+		zl := zap.New(core)
+
+		// When
+		logger, err := log.NewPluginHostLogger(zl)
+
+		// Then
+		require.NoError(t, err)
+		assert.True(t, logger.IsDebug())
+		assert.True(t, logger.IsInfo())
+	})
+	t.Run("will honor a higher level from the wrapped zap logger", func(t *testing.T) {
+		// Given a zap logger enabled only at warn and above
+		core := zapcore.NewCore(
+			zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+			zapcore.AddSync(io.Discard),
+			zapcore.WarnLevel,
+		)
+		zl := zap.New(core)
+
+		// When
+		logger, err := log.NewPluginHostLogger(zl)
+
+		// Then
+		require.NoError(t, err)
+		assert.False(t, logger.IsDebug())
+		assert.False(t, logger.IsInfo())
+		assert.True(t, logger.IsWarn())
+		assert.True(t, logger.IsError())
+	})
+	t.Run("will relay entries through the wrapped zap logger", func(t *testing.T) {
+		// Given a zap logger writing JSON to a buffer
+		var buf bytes.Buffer
+		core := zapcore.NewCore(
+			zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+			zapcore.AddSync(&buf),
+			zapcore.InfoLevel,
+		)
+		zl := zap.New(core)
+		logger, err := log.NewPluginHostLogger(zl)
+		require.NoError(t, err)
+
+		// When
+		logger.Info("relayed message", "key", "value")
+
+		// Then the entry is encoded by zap with the message and key/value pair
+		var entry map[string]interface{}
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+		assert.Equal(t, "relayed message", entry["msg"])
+		assert.Equal(t, "value", entry["key"])
+	})
+}
+
 func TestLogWrapper(t *testing.T) {
 	type fixture struct {
 		logger *log.LogWrapper

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -32,14 +32,41 @@ func TestLoggerConfiguration(t *testing.T) {
 }
 
 func TestPluginLogger(t *testing.T) {
-	t.Run("will validate if named correctly", func(t *testing.T) {
+	t.Run("will validate if configs are applied without error", func(t *testing.T) {
 		// When
-		zl := zaptest.NewLogger(t)
-		logger, err := log.NewPluginLogger(zl)
+		logger, err := log.NewPluginLogger(
+			log.WithLevel(log.DebugLevel),
+			log.WithFormat(log.JsonFormat),
+		)
 
 		// Then
 		assert.NoError(t, err)
 		assert.NotNil(t, logger)
+		assert.True(t, logger.IsDebug())
+		assert.Equal(t, "plugin", logger.Name())
+	})
+	t.Run("will validate if default configurations are applied", func(t *testing.T) {
+		// When
+		logger, err := log.NewPluginLogger()
+
+		// Then
+		assert.NoError(t, err)
+		assert.NotNil(t, logger)
+		assert.True(t, logger.IsInfo())
+		assert.Equal(t, "plugin", logger.Name())
+	})
+	t.Run("will validate if provided configs takes precedence", func(t *testing.T) {
+		// When
+		logger, err := log.NewPluginLogger(
+			log.WithLevel(log.InfoLevel),
+			log.WithFormat(log.TextFormat),
+		)
+
+		// Then
+		assert.NoError(t, err)
+		assert.NotNil(t, logger)
+		assert.False(t, logger.IsDebug())
+		assert.True(t, logger.IsInfo())
 		assert.Equal(t, "plugin", logger.Name())
 	})
 }

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/argoproj-labs/argocd-ephemeral-access/pkg/log"
 	"github.com/go-logr/logr"
+	hclog "github.com/hashicorp/go-hclog"
 	"github.com/go-logr/zapr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,6 +19,21 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 )
+
+// captureHCLogOutput redirects hclog's default output while fn runs and returns
+// what was written. NewPluginLogger does not set an explicit Output, so hclog
+// writes to hclog.DefaultOutput (which it snapshots at logger construction),
+// not to the current os.Stderr. The logger must therefore be built inside fn.
+func captureHCLogOutput(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := hclog.DefaultOutput
+	var buf bytes.Buffer
+	hclog.DefaultOutput = &buf
+	defer func() { hclog.DefaultOutput = orig }()
+
+	fn()
+	return buf.String()
+}
 
 func TestLoggerConfiguration(t *testing.T) {
 	t.Run("will validate if default configurations are applied", func(t *testing.T) {
@@ -32,9 +48,55 @@ func TestLoggerConfiguration(t *testing.T) {
 }
 
 func TestPluginLogger(t *testing.T) {
+	t.Run("will return error when logger is nil", func(t *testing.T) {
+		// When
+		logger, err := log.NewPluginLogger(nil)
+
+		// Then
+		assert.Error(t, err)
+		assert.Nil(t, logger)
+	})
+	t.Run("will derive the level from the provided zap logger", func(t *testing.T) {
+		// Given a zap logger enabled at debug level
+		core := zapcore.NewCore(
+			zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+			zapcore.AddSync(io.Discard),
+			zapcore.DebugLevel,
+		)
+		zl := zap.New(core)
+
+		// When
+		logger, err := log.NewPluginLogger(zl)
+
+		// Then
+		require.NoError(t, err)
+		assert.NotNil(t, logger)
+		assert.True(t, logger.IsDebug())
+		assert.Equal(t, "plugin", logger.Name())
+	})
+	t.Run("will honor a higher level from the provided zap logger", func(t *testing.T) {
+		// Given a zap logger enabled only at info and above
+		core := zapcore.NewCore(
+			zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+			zapcore.AddSync(io.Discard),
+			zapcore.InfoLevel,
+		)
+		zl := zap.New(core)
+
+		// When
+		logger, err := log.NewPluginLogger(zl)
+
+		// Then
+		require.NoError(t, err)
+		assert.False(t, logger.IsDebug())
+		assert.True(t, logger.IsInfo())
+	})
+}
+
+func TestPluginLoggerWithOpts(t *testing.T) {
 	t.Run("will validate if configs are applied without error", func(t *testing.T) {
 		// When
-		logger, err := log.NewPluginLogger(
+		logger, err := log.NewPluginLoggerWithOpts(
 			log.WithLevel(log.DebugLevel),
 			log.WithFormat(log.JsonFormat),
 		)
@@ -47,7 +109,7 @@ func TestPluginLogger(t *testing.T) {
 	})
 	t.Run("will validate if default configurations are applied", func(t *testing.T) {
 		// When
-		logger, err := log.NewPluginLogger()
+		logger, err := log.NewPluginLoggerWithOpts()
 
 		// Then
 		assert.NoError(t, err)
@@ -55,11 +117,10 @@ func TestPluginLogger(t *testing.T) {
 		assert.True(t, logger.IsInfo())
 		assert.Equal(t, "plugin", logger.Name())
 	})
-	t.Run("will validate if provided configs takes precedence", func(t *testing.T) {
+	t.Run("will validate if provided level takes precedence", func(t *testing.T) {
 		// When
-		logger, err := log.NewPluginLogger(
+		logger, err := log.NewPluginLoggerWithOpts(
 			log.WithLevel(log.InfoLevel),
-			log.WithFormat(log.TextFormat),
 		)
 
 		// Then
@@ -69,9 +130,32 @@ func TestPluginLogger(t *testing.T) {
 		assert.True(t, logger.IsInfo())
 		assert.Equal(t, "plugin", logger.Name())
 	})
+	t.Run("will always emit hclog JSON so the host can parse the message", func(t *testing.T) {
+		// When a logger built asking for text format logs an entry. hclog
+		// snapshots its output at construction, so it must be built inside the
+		// capture to observe its output.
+		out := captureHCLogOutput(t, func() {
+			logger, err := log.NewPluginLoggerWithOpts(
+				log.WithName("some-plugin"),
+				log.WithFormat(log.TextFormat),
+			)
+			require.NoError(t, err)
+			logger.Info("granted access", "user", "leo")
+		})
+
+		// Then the output is hclog JSON, so @message carries only the message
+		// and can be relayed into the host "msg" field verbatim.
+		var entry map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(out), &entry),
+			"expected JSON output regardless of the requested format, got: %s", out)
+		assert.Equal(t, "granted access", entry["@message"])
+		assert.Equal(t, "info", entry["@level"])
+		assert.Equal(t, "some-plugin", entry["@module"])
+		assert.Equal(t, "leo", entry["user"])
+	})
 	t.Run("will use the provided name", func(t *testing.T) {
 		// When
-		logger, err := log.NewPluginLogger(log.WithName("my-plugin"))
+		logger, err := log.NewPluginLoggerWithOpts(log.WithName("my-plugin"))
 
 		// Then
 		assert.NoError(t, err)
@@ -80,7 +164,7 @@ func TestPluginLogger(t *testing.T) {
 	})
 	t.Run("will default the name to plugin", func(t *testing.T) {
 		// When
-		logger, err := log.NewPluginLogger()
+		logger, err := log.NewPluginLoggerWithOpts()
 
 		// Then
 		assert.NoError(t, err)

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -69,6 +69,24 @@ func TestPluginLogger(t *testing.T) {
 		assert.True(t, logger.IsInfo())
 		assert.Equal(t, "plugin", logger.Name())
 	})
+	t.Run("will use the provided name", func(t *testing.T) {
+		// When
+		logger, err := log.NewPluginLogger(log.WithName("my-plugin"))
+
+		// Then
+		assert.NoError(t, err)
+		assert.NotNil(t, logger)
+		assert.Equal(t, "my-plugin", logger.Name())
+	})
+	t.Run("will default the name to plugin", func(t *testing.T) {
+		// When
+		logger, err := log.NewPluginLogger()
+
+		// Then
+		assert.NoError(t, err)
+		assert.NotNil(t, logger)
+		assert.Equal(t, "plugin", logger.Name())
+	})
 }
 
 func TestPluginHostLogger(t *testing.T) {


### PR DESCRIPTION
Plugin logs were previously produced by wrapping the controller's zap.Logger
with the third-party zaffka/zap-to-hclog on both sides of the go-plugin RPC
boundary (introduced in #123 to unify the plugin and controller log formats).
That wrapper re-encoded the plugin's own output in zap's format, which the
go-plugin host could not parse: it recognizes only native hclog JSON or
[LEVEL]-prefixed text, so every relayed entry fell through to Debug and lost its
real level and message.

This splits the two loggers by their actual role and encodes each correctly:

- Plugin emitter (examples/plugin/cmd/main.go): NewPluginLogger now builds a
  native hclog.Logger, whose output the go-plugin host parses correctly. Because
  the plugin runs in a separate subprocess without access to the controller
  config, main derives the logger level and format from the EPHEMERAL_LOG_LEVEL
  and EPHEMERAL_LOG_FORMAT env variables the controller propagates.

- Host relay (cmd/controller/controller.go): initPlugin builds the relay logger
  from the controller's zap.Logger via the new NewPluginHostLogger, so entries
  relayed from the plugin are encoded exactly like the controller's own logs.
  This logger is output-only and never crosses the parse boundary, so wrapping
  zap here is safe.

The zap->hclog adaptation is now a small in-repo adapter (pkg/log/hclog_adapter.go)
instead of zaffka/zap-to-hclog, whose hclog conformance was poor: it hardcoded
every Is*() level check to false and made SetLevel a no-op. The in-repo adapter
reports levels from the underlying zap core, maps hclog's Trace level to zap's
Debug, composes named loggers correctly, and converts key/value args to zap
fields without dropping any. This removes the zaffka/zap-to-hclog dependency.

Also restores EPHEMERAL_LOG_LEVEL=debug on the controller Procfile entry for
local development.